### PR TITLE
Add numpy and scipy as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://libigl.github.io/libigl-python-bindings/",
     ext_modules=[CMakeExtension('pyigl')],
+    install_requires=[ 'numpy', 'scipy' ],
     cmdclass=dict(build_ext=CMakeBuild),
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
numpy and scipy should be marked as dependencies in `setup.py` via `install_requires`. The module cannot be compiled (numpy) or imported (numpy and scipy) without them.