### PR TITLE
Update remove_duplicate_vertices docs to match the call signature and return

### DIFF
--- a/src/remove_duplicate_vertices.cpp
+++ b/src/remove_duplicate_vertices.cpp
@@ -26,7 +26,7 @@ Returns
 SV  #SV by dim new list of vertex positions
 SVI #V by 1 list of indices so SV = V(SVI,:) 
 SVJ #SV by 1 list of indices so V = SV(SVJ,:)
-SF  #SF by 1 dim new list of faces so SF = F(SVJ,:)
+SF  #SF by dim new list of faces so SF = F(SVJ,:)
 
 See also
 --------

--- a/src/remove_duplicate_vertices.cpp
+++ b/src/remove_duplicate_vertices.cpp
@@ -39,7 +39,7 @@ None
 Examples
 --------
 % Mesh in (V,F)
-[SV,SVI,SVJ] = remove_duplicate_vertices(V,F,1e-7);
+[SV,SVI,SVJ,SF] = remove_duplicate_vertices(V,F,1e-7);
 % remap faces
 SF = SVJ(F);
   

--- a/src/remove_duplicate_vertices.cpp
+++ b/src/remove_duplicate_vertices.cpp
@@ -26,7 +26,7 @@ Returns
 SV  #SV by dim new list of vertex positions
 SVI #V by 1 list of indices so SV = V(SVI,:) 
 SVJ #SV by 1 list of indices so V = SV(SVJ,:)
-Wrapper that also remaps given faces (F) --> (SF) so that SF index SV
+SF  #SF by 1 dim new list of faces so SF = F(SVJ,:)
 
 See also
 --------
@@ -39,7 +39,7 @@ None
 Examples
 --------
 % Mesh in (V,F)
-[SV,SVI,SVJ] = remove_duplicate_vertices(V,1e-7);
+[SV,SVI,SVJ] = remove_duplicate_vertices(V,F,1e-7);
 % remap faces
 SF = SVJ(F);
   


### PR DESCRIPTION
- Docs show that `f` is not required, but the bound function is called with it.  This might be optional there, but I haven't checked.
- Docs show returning three objects and then how to map new faces, but this is already done in the function, and they are returned (validated by `np.all(SVJ[f] == SF)`).