### PR TITLE
Fix typos in the tutorial

### DIFF
--- a/tutorial/index.md
+++ b/tutorial/index.md
@@ -11,12 +11,12 @@ igl python bindings
 
 [libigl](https://libigl.github.io) is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet, and edge-based topology data structures.
 
-All these functionalities are now available trough python and can be easily installed with conda:
+All these functionalities are now available through python and can be easily installed with conda:
 ```bash
 conda install -c conda-forge igl
 ```
 
 We provide a complete jupyter version of the tutorials and the full [documentation](igl_docs.md).
 
-The full tutorial can be interactively run trough mybinder
+The full tutorial can be interactively run through mybinder
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/libigl/libigl-python-bindings/master?filepath=tutorial%2Ftutorials.ipynb)


### PR DESCRIPTION
Thank you for maintaining this nice library.

Just a very minor fix: if my understanding is correct, "trough" should be "through".