### PR TITLE
face_components -> facet_components

### DIFF
--- a/src/facet_components.cpp
+++ b/src/facet_components.cpp
@@ -3,7 +3,7 @@
 #include <typedefs.h>
 #include <igl/facet_components.h>
 
-const char* ds_face_components = R"igl_Qu8mg5v7(
+const char* ds_facet_components = R"igl_Qu8mg5v7(
 Compute connected components of facets based on edge-edge adjacency,
 
 Parameters
@@ -27,8 +27,8 @@ Examples
 
 )igl_Qu8mg5v7";
 
-npe_function(face_components)
-npe_doc(ds_face_components)
+npe_function(facet_components)
+npe_doc(ds_facet_components)
 npe_arg(f, dense_int, dense_long, dense_longlong)
 npe_begin_code()
     assert_valid_tri_mesh_faces(f);

--- a/src/vertex_components.cpp
+++ b/src/vertex_components.cpp
@@ -17,7 +17,7 @@ An array of component ids (starting with 0)
 See also
 --------
 vertex_components_from_adjacency_matrix
-face_components_from_faces
+facet_components
 
 Notes
 -----
@@ -54,7 +54,7 @@ and counts is a #components array of counts for each component
 See also
 --------
 vertex_components
-face_components
+facet_components
 
 Notes
 -----

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -307,8 +307,8 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(c.shape[0], self.v1.shape[0])
         self.assertTrue(c.flags.c_contiguous)
 
-    def test_face_components(self):
-        c = igl.face_components(self.f1)
+    def test_facet_components(self):
+        c = igl.facet_components(self.f1)
         self.assertEqual(c.shape, (self.f1.shape[0],))
         self.assertTrue(np.array_equal(c, np.zeros_like(c)))
         self.assertTrue(c.flags.c_contiguous)

--- a/tutorial/igl_docs.md
+++ b/tutorial/igl_docs.md
@@ -1071,8 +1071,8 @@ Assumes the input mesh have all -intersection resolved.  See ``igl::cgal::remesh
 |Returns| curves  An array of arries of unique edge indices. |
 
 
-### face_components
-**`face_components(f: array)`**
+### facet_components
+**`facet_components(f: array)`**
 
 Compute connected components of facets based on edge-edge adjacency,
 
@@ -2912,7 +2912,7 @@ Compute connected components of the vertices of a mesh given the mesh' face indi
 |-|-|
 |Parameters| f : \#f x dim array of face indices |
 |Returns| An array of component ids (starting with 0) |
-|See also| vertex_components_from_adjacency_matrix</br>face_components_from_faces |
+|See also| vertex_components_from_adjacency_matrix</br>facet_components |
 
 
 ### vertex_components_from_adjacency_matrix
@@ -2925,7 +2925,7 @@ matrix.
 |-|-|
 |Parameters| a : n by n sparse adjacency matrix |
 |Returns| A tuple (c, counts) where c is an array of component ids (starting with 0)</br>and counts is a \#components array of counts for each component |
-|See also| vertex_components</br>face_components |
+|See also| vertex_components</br>facet_components |
 
 
 ### vertex_triangle_adjacency


### PR DESCRIPTION
Renamed `face_components` to `facet_components`.

I don't know if this is a typo or on purpose?!
I found it quite confusing as the underlying C++ function is `igl::facet_components()`.

Also replaced reference to `face_components_from_faces` with `facet_components` as the former does not (yet?) exist.

If the PR is obsolet, it might be a good idea to add a hint somewhere.