### PR TITLE
Fix misleading error message when reading OBJ

### DIFF
--- a/src/readOBJ.cpp
+++ b/src/readOBJ.cpp
@@ -5,7 +5,7 @@
 
 const char* ds_read_obj = R"igl_Qu8mg5v7(
 Read a mesh from an ascii obj file, filling in vertex positions, normals
-and texture coordinates. Mesh may have faces of any number of degree.
+and texture coordinates. Only meshes with constant face degree are supported.
 
 Parameters
 ----------
@@ -46,7 +46,7 @@ npe_begin_code()
     EigenDenseInt f, ftc, fn;
     bool ret = igl::readOBJ(filename, v, tc, n, f, ftc, fn);
     if (!ret) {
-      throw std::invalid_argument("File '" + filename + "' not found.");
+      throw std::invalid_argument("File '" + filename + "' not found or containing faces of varying degree (which is not supported yet).");
     }
     return std::make_tuple(npe::move(v), npe::move(tc), npe::move(n), npe::move(f), npe::move(ftc), npe::move(fn));
   } else if (dtype.type() == npe::type_f64) {
@@ -54,7 +54,7 @@ npe_begin_code()
     EigenDenseInt f, ftc, fn; // TODO weird problem, int64 gives int128 dtype in numpy
     bool ret = igl::readOBJ(filename, v, tc, n, f, ftc, fn);
     if (!ret) {
-      throw std::invalid_argument("File '" + filename + "' not found.");
+      throw std::invalid_argument("File '" + filename + "' not found or containing faces of varying degree (which is not supported yet).");
     }
     return std::make_tuple(npe::move(v), npe::move(tc), npe::move(n), npe::move(f), npe::move(ftc), npe::move(fn));
   } else {


### PR DESCRIPTION
Reading a file with varying face degree returned message "file not
found" even though the error was coming from something else.

Also fix the docstring that was incorrect.

Eventually we should fall back to the other overloads of [igl::readOBJ](https://github.com/libigl/libigl/blob/master/include/igl/readOBJ.h#L44)
(potentially adding an optional argument to read_obj).

Suggested fix to #71