### PR TITLE
Fixed adjacency matrix requirements for 3/4 simplices

### DIFF
--- a/src/adjacency_matrix.cpp
+++ b/src/adjacency_matrix.cpp
@@ -42,7 +42,7 @@ npe_doc(ds_adjacency_matrix)
 npe_arg(f, dense_int, dense_long, dense_longlong)
 npe_begin_code()
 
-  assert_valid_tet_or_tri_mesh_faces(f, "f");
+  assert_valid_simplex_idxs(f, "f");
   EigenSparseLike<npe_Matrix_f> a;
   igl::adjacency_matrix(f, a);
   return npe::move(a);

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -121,6 +121,19 @@ void assert_valid_tet_or_tri_mesh_faces(const TF& f, std::string f_name="f") {
 }
 
 template <typename TF>
+void assert_valid_simplex_idxs(const TF& f, std::string f_name="f") {
+    if (f.rows() <= 0) {
+        throw pybind11::value_error("Invalid simplex indices, " + f_name + " has zero rows (" + f_name + ".shape = [" +
+                                    std::to_string(f.rows()) + ", " + std::to_string(f.cols()) + "]) ");
+    }
+
+    if (f.cols() < 2) {
+        throw pybind11::value_error("Invalid simplex indices, " + f_name + " must have shape [#faces, #edges] with #edges >= 2 for a valid simplex." +
+                                    "but got " + f_name + ".shape = [" + std::to_string(f.rows()) + ", " + std::to_string(f.cols()) + "]");
+    }
+}
+
+template <typename TF>
 void assert_valid_tri_mesh_faces(const TF &f, std::string f_name = "f")
 {
     if (f.rows() <= 0)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -76,9 +76,13 @@ class TestBasic(unittest.TestCase):
     # sparse matrix, no flag attribute
     def test_adjacency_matrix(self):
         a = igl.adjacency_matrix(self.f)
+        b = igl.adjacency_matrix(self.f[:,:2]) # Test with edges only
         self.assertTrue(a.shape == (self.v.shape[0], self.v.shape[0]))
+        self.assertTrue(b.shape == (self.v.shape[0], self.v.shape[0]))
         self.assertTrue(a.dtype == self.f.dtype)
+        self.assertTrue(b.dtype == self.f.dtype)
         self.assertTrue(type(a) == csc.csc_matrix)
+        self.assertTrue(type(b) == csc.csc_matrix)
 
     def test_avg_edge_length(self):
         l = igl.avg_edge_length(self.v1, self.f1)


### PR DESCRIPTION
- Added a function called `assert_valid_simplex_idxs` to ensure that an #Nx#M where #M>= 2 is provided, instead of #M==3 | #M == 4 which was a previous requirement for using `adjacency_matrix`. 
- Adjacency matrices can now be built with edge lists:
```
>>> import numpy as np
>>> import igl
>>> a = np.array([[0,1], [1,2], [2,3], [3,0]])
>>> igl.adjacency_matrix(a)
<4x4 sparse matrix of type '<class 'numpy.longlong'>'
        with 8 stored elements in Compressed Sparse Column format>
```