### PR TITLE
fix the edit button in the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_url: 'https://github.com/libigl/libigl-python-bindings'
 site_description: "Simple Python geometry processing library"
 # strict: true
 docs_dir: 'tutorial'
+edit_uri: 'edit/master/tutorial/'
 remote_branch: 'gh-pages'
 theme:
   name: material


### PR DESCRIPTION
Per https://www.mkdocs.org/user-guide/configuration/#edit_uri. Although edit_uri is auto derived on github, it points to edit/master/docs/, not edit/master/tutorial/