### PR TITLE
Fixed CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,23 +8,38 @@ jobs:
   strategy:
     matrix:
       mac35:
-        imageName: 'macos-10.14'
+        imageName: 'macos-10.15'
         python.version: '3.5'
       mac36:
-        imageName: 'macos-10.14'
+        imageName: 'macos-10.15'
         python.version: '3.6'
       mac37:
-        imageName: 'macos-10.14'
+        imageName: 'macos-10.15'
         python.version: '3.7'
-      windows35:
-        imageName: 'vs2017-win2016'
-        python.version: '3.5'
+      mac38:
+        imageName: 'macos-10.15'
+        python.version: '3.8'
+      mac39:
+        imageName: 'macos-10.15'
+        python.version: '3.9'
+      mac310:
+        imageName: 'macos-10.15'
+        python.version: '3.10'
       windows36:
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         python.version: '3.6'
       windows37:
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         python.version: '3.7'
+      windows38:
+        imageName: 'windows-2019'
+        python.version: '3.8'
+      windows39:
+        imageName: 'windows-2019'
+        python.version: '3.9'
+      windows310:
+        imageName: 'windows-2019'
+        python.version: '3.10'
 
   pool:
     vmImage: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,9 +7,6 @@ jobs:
   timeoutInMinutes: 0
   strategy:
     matrix:
-      mac35:
-        imageName: 'macos-10.15'
-        python.version: '3.5'
       mac36:
         imageName: 'macos-10.15'
         python.version: '3.6'

--- a/setup.py
+++ b/setup.py
@@ -54,28 +54,28 @@ class CMakeBuild(build_ext):
         else:
             build_args += ['--', '-j2']
 
-        tmp = os.environ.get("AR")
+        tmp = os.environ.get("AR", "")
         if "arm64-apple" in tmp:
-            tmp = os.environ.get("CMAKE_ARGS")
+            tmp = os.environ.get("CMAKE_ARGS", "")
             if tmp:
                 cmake_args += tmp.split(" ")
 
-            tmp = os.environ.get("CC")
+            tmp = os.environ.get("CC", "")
             print("C compiler", tmp)
             if tmp:
                 cmake_args += ["-DCMAKE_C_COMPILER={}".format(tmp)]
 
-            tmp = os.environ.get("CXX")
+            tmp = os.environ.get("CXX", "")
             print("CXX compiler", tmp)
             if tmp:
                 cmake_args += ["-DCMAKE_CXX_COMPILER={}".format(tmp)]
         else:
-            tmp = os.getenv('CC_FOR_BUILD')
+            tmp = os.getenv('CC_FOR_BUILD', '')
             if tmp:
                 print("Setting c compiler to", tmp)
                 cmake_args += ["-DCMAKE_C_COMPILER=" + tmp]
 
-            tmp = os.getenv('CXX_FOR_BUILD')
+            tmp = os.getenv('CXX_FOR_BUILD', '')
             if tmp:
                 print("Setting cxx compiler to", tmp)
                 cmake_args += ["-DCMAKE_CXX_COMPILER="+ tmp]
@@ -85,14 +85,14 @@ class CMakeBuild(build_ext):
 
 
 
-        tmp = os.getenv("target_platform")
+        tmp = os.getenv("target_platform", "")
         if tmp:
             print("target platfrom", tmp)
             if "arm" in tmp:
                 cmake_args += ["-DCMAKE_OSX_ARCHITECTURES=arm64"]
 
         # print(cmake_args)
-        # tmp = os.getenv('CMAKE_ARGS')
+        # tmp = os.getenv('CMAKE_ARGS', '')
 
         # if tmp:
         #     tmp = tmp.split(" ")

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ class CMakeBuild(build_ext):
 
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            if os.environ.get('CMAKE_GENERATOR') != "NMake Makefiles" and "Ninja" not in os.environ.get('CMAKE_GENERATOR'):
+            cmake_generator = os.environ.get('CMAKE_GENERATOR', '')
+            if cmake_generator != "NMake Makefiles" and "Ninja" not in cmake_generator:
                 if sys.maxsize > 2**32:
                     cmake_args += ['-A', 'x64']
                 # build_args += ['--', '/m']


### PR DESCRIPTION
## Error Description
The [errors](https://github.com/libigl/libigl-python-bindings/runs/5103264270) were:
- Use obsoleted python 3.5, [see](https://endoflife.date/python)
- Sometimes, `os.environ.get("KEY")` may return NoneType 

## PR Description
- remove python-3.5 from `azure-piplines.yml`
- Use `os.environ.get("KEY", "")` for preventing NoneType
- Upgrade the version of OS images:
  [`macos-10.13` -> `macos-10.15`](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml)
  [`vs2017-win2016` -> `windows-2019`](https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/)

CI build Result: https://dev.azure.com/n66/PublicCI/_build/results?buildId=114&view=results

@teseoch 