### PR TITLE
CGAL module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,12 @@ include(Warnings)
 include(CXXFeatures)
 
 option(PY_IGL_PYTHON_TESTS          "Run Python tests"   ON)
+message(STATUS "PY_IGL_PYTHON_TESTS: ${PY_IGL_PYTHON_TESTS}")
 
+
+option(LIBIGL_COPYLEFT_CGAL "Build target igl_copyleft::cgal"       ON)
+# libigl options must come before include(PyiglDependencies)
 include(PyiglDependencies)
-
 if(NOT TARGET igl::core)
   include(libigl)
 endif()
@@ -31,15 +34,22 @@ include(numpyeigen)
 
 # A module for writing bindings with our framework
 file(GLOB PYIGL_SOURCES src/*.cpp)
-
 npe_add_module(pyigl
   BINDING_SOURCES
-  ${PYIGL_SOURCES}
-  ${PYIGL_SOURCES_COPYLEFT})
-
-#TODO move additional libs to variable
+  ${PYIGL_SOURCES})
 target_link_libraries(pyigl PRIVATE igl::core)
 target_include_directories(pyigl PRIVATE "src/include")
+
+if(LIBIGL_COPYLEFT_CGAL)
+  file(GLOB PYIGL_COPYLEFT_CGAL_SOURCES src/copyleft/cgal/*.cpp)
+  npe_add_module(pyigl_copyleft_cgal
+    BINDING_SOURCES
+    ${PYIGL_COPYLEFT_CGAL_SOURCES})
+  target_link_libraries(pyigl_copyleft_cgal PRIVATE igl::core igl_copyleft::cgal)
+  target_include_directories(pyigl_copyleft_cgal PRIVATE "src/include")
+  target_link_libraries(pyigl INTERFACE pyigl_copyleft_cgal)
+endif()
+
 
 add_library(pyigl_classes MODULE classes/classes.cpp)
 target_link_libraries(pyigl_classes PRIVATE npe igl::core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,16 +39,39 @@ npe_add_module(pyigl
   ${PYIGL_SOURCES})
 target_link_libraries(pyigl PRIVATE igl::core)
 target_include_directories(pyigl PRIVATE "src/include")
+set_target_properties(pyigl PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
-if(LIBIGL_COPYLEFT_CGAL)
-  file(GLOB PYIGL_COPYLEFT_CGAL_SOURCES src/copyleft/cgal/*.cpp)
-  npe_add_module(pyigl_copyleft_cgal
-    BINDING_SOURCES
-    ${PYIGL_COPYLEFT_CGAL_SOURCES})
-  target_link_libraries(pyigl_copyleft_cgal PRIVATE igl::core igl_copyleft::cgal)
-  target_include_directories(pyigl_copyleft_cgal PRIVATE "src/include")
-  target_link_libraries(pyigl INTERFACE pyigl_copyleft_cgal)
-endif()
+# don't need to worry about nested modules (opengl/** are the only ones and
+# those probably aren't ever getting python bindings)
+#
+# prefix is either "", "copyleft", or "restricted"
+function(pyigl_include prefix name)
+  string(TOUPPER "${prefix}" prefix_uc)
+  string(TOUPPER "${name}" name_uc)
+  if(prefix_uc)
+      string(PREPEND prefix_uc _)
+  endif()
+  string(TOLOWER "${prefix_uc}" prefix_lc)
+  if(LIBIGL${prefix_uc}_${name_uc})
+    if(${prefix} STREQUAL "copyleft")
+      set(subpath "copyleft/${name}")
+    else() # "" or "restricted"
+      set(subpath "${name}")
+    endif()
+    file(GLOB sources src/${subpath}/*.cpp)
+    set(target_name "pyigl${prefix_lc}_${name}")
+    npe_add_module(                            ${target_name} BINDING_SOURCES ${sources})
+    target_link_libraries(                     ${target_name} PRIVATE igl::core igl${prefix_lc}::${name})
+    target_include_directories(                ${target_name} PRIVATE "src/include")
+    set(output_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${subpath}")
+    file(MAKE_DIRECTORY ${output_dir})
+    file(WRITE "${output_dir}/__init__.py" "from .${target_name} import *")
+    set_target_properties(${target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${output_dir}")
+    target_link_libraries(     pyigl INTERFACE ${target_name})
+  endif()
+endfunction()
+
+pyigl_include("copyleft" "cgal")
 
 
 add_library(pyigl_classes MODULE classes/classes.cpp)

--- a/cmake/PyiglDependencies.cmake
+++ b/cmake/PyiglDependencies.cmake
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
     libigl
     GIT_REPOSITORY https://github.com/libigl/libigl.git
-    GIT_TAG v2.4.0
+    GIT_TAG 4fa1e22c8f30536477d20013f555dec2d7dba119
 )
 FetchContent_MakeAvailable(libigl)
 

--- a/cmake/PyiglDependencies.cmake
+++ b/cmake/PyiglDependencies.cmake
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
     libigl
     GIT_REPOSITORY https://github.com/libigl/libigl.git
-    GIT_TAG 4fa1e22c8f30536477d20013f555dec2d7dba119
+    GIT_TAG 1c3d487d8e77f816934374c271ef978807003405
 )
 FetchContent_MakeAvailable(libigl)
 

--- a/igl/__init__.py
+++ b/igl/__init__.py
@@ -1,4 +1,3 @@
 from .pyigl import *
-from .pyigl_copyleft_cgal import *
 from .helpers import *
 from .pyigl_classes import *

--- a/igl/__init__.py
+++ b/igl/__init__.py
@@ -1,3 +1,4 @@
 from .pyigl import *
+from .pyigl_copyleft_cgal import *
 from .helpers import *
 from .pyigl_classes import *

--- a/scripts/generate_bindings.py
+++ b/scripts/generate_bindings.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
 
     # Parse c++ header files
     print("Parsing header files...")
-    load_headers = True
+    load_headers = False
     if load_headers:
         with open("headers.dat", 'rb') as fs:
             dicts = pickle.load(fs)
@@ -291,7 +291,7 @@ if __name__ == '__main__':
             # Write binding files
             try:
                 tpl = Template(filename='basic_function.mako')
-                #print(correct_functions)
+                print(correct_functions)
                 includes = ["<npe.h>", "<typedefs.h>"]
                 rendered = tpl.render(functions=correct_functions, enums=enums, includes=includes)
                 tpl1 = Template(filename='basic_function.mako')

--- a/src/copyleft/cgal/convex_hull.cpp
+++ b/src/copyleft/cgal/convex_hull.cpp
@@ -1,0 +1,48 @@
+#include <npe.h>
+#include <typedefs.h>
+
+#include <igl/copyleft/cgal/convex_hull.h>
+
+const char* ds_convex_hull = R"igl_Qu8mg5v7(
+
+Parameters
+----------
+
+
+Returns
+-------
+
+
+See also
+--------
+
+
+Notes
+-----
+None
+
+Examples
+--------
+
+ Given a set of points (V), compute the convex hull as a triangle mesh (W,G)
+       
+       Inputs:
+         V  #V by 3 list of input points
+       Outputs:
+         W  #W by 3 list of convex hull points
+         G  #G by 3 list of triangle indices into W
+)igl_Qu8mg5v7";
+
+npe_function(convex_hull)
+npe_doc(ds_convex_hull)
+
+npe_arg(v, dense_float, dense_double)
+npe_begin_code()
+
+  EigenDenseLike<npe_Matrix_v> w;
+  EigenDenseInt g;
+  igl::copyleft::cgal::convex_hull(v, w, g);
+  return std::make_tuple(npe::move(w), npe::move(g));
+
+npe_end_code()
+

--- a/src/copyleft/cgal/convex_hull.cpp
+++ b/src/copyleft/cgal/convex_hull.cpp
@@ -4,33 +4,15 @@
 #include <igl/copyleft/cgal/convex_hull.h>
 
 const char* ds_convex_hull = R"igl_Qu8mg5v7(
-
+Given a set of points (V), compute the convex hull as a triangle mesh (F)
+       
 Parameters
 ----------
-
+V :  #V by 3 list of input points
 
 Returns
 -------
-
-
-See also
---------
-
-
-Notes
------
-None
-
-Examples
---------
-
- Given a set of points (V), compute the convex hull as a triangle mesh (W,G)
-       
-       Inputs:
-         V  #V by 3 list of input points
-       Outputs:
-         W  #W by 3 list of convex hull points
-         G  #G by 3 list of triangle indices into W
+F  #F by 3 list of triangle indices into V
 )igl_Qu8mg5v7";
 
 npe_function(convex_hull)
@@ -39,10 +21,11 @@ npe_doc(ds_convex_hull)
 npe_arg(v, dense_float, dense_double)
 npe_begin_code()
 
-  EigenDenseLike<npe_Matrix_v> w;
   EigenDenseInt g;
-  igl::copyleft::cgal::convex_hull(v, w, g);
-  return std::make_tuple(npe::move(w), npe::move(g));
+  // when https://github.com/libigl/libigl/pull/1989 is merged this copy should
+  // be removed
+  Eigen::MatrixXd v_copy = v.template cast<double>();
+  igl::copyleft::cgal::convex_hull(v_copy, g);
+  return npe::move(g);
 
 npe_end_code()
-

--- a/src/copyleft/cgal/intersect_other.cpp
+++ b/src/copyleft/cgal/intersect_other.cpp
@@ -1,0 +1,87 @@
+#include <npe.h>
+#include <typedefs.h>
+#include <igl/copyleft/cgal/intersect_other.h>
+
+
+
+const char* ds_intersect_other = R"igl_Qu8mg5v7(
+INTERSECT_OTHER Given a triangle mesh (VA,FA) and another mesh (VB,FB) find all
+pairs of intersecting faces. Note that self-intersections are ignored.
+      
+
+Parameters
+----------
+VA  : #VA by 3 list of vertex positions of first mesh
+FA  : #FA by 3 list of triangle indices into VA
+VB  : #VB by 3 list of vertex positions of second mesh
+FB  : #FB by 3 list of triangle indices into VB
+detect_only : avoid constructing intersections results when possible  {false}
+first_only  : return after detecting the first intersection (if
+  first_only==true, then detect_only should also be true) {false}
+stitch_all  : whether to stitch all resulting constructed elements into a
+  (non-manifold) mesh  {false}
+slow_and_more_precise_rounding  : whether to use slow and more precise
+  rounding (see assign_scalar) {false}
+
+
+Returns
+-------
+IF : #intersecting face pairs by 2  list of intersecting face pairs, indexing F
+VVAB : #VVAB by 3 list of vertex positions
+FFAB : #FFAB by 3 list of triangle indices into VVAB
+JAB  : #FFAB list of indices into [FA;FB] denoting birth triangle
+IMAB :  #VVAB list of indices stitching duplicates (resulting from
+  mesh intersections) together
+      
+See also
+--------
+mesh_boolean
+)igl_Qu8mg5v7";
+
+npe_function(intersect_other)
+npe_doc(  ds_intersect_other)
+
+npe_arg(VA, dense_float, dense_double)
+npe_arg(FA, dense_int, dense_long, dense_longlong)
+npe_arg(VB, npe_matches(VA))
+npe_arg(FB, npe_matches(FA))
+npe_default_arg(detect_only, bool, false)
+npe_default_arg(first_only, bool, false)
+npe_default_arg(stitch_all, bool, false)
+// Awaiting bump in libigl
+//npe_default_arg(slow_and_more_precise_rounding, bool, false)
+
+
+npe_begin_code()
+  Eigen::MatrixXd VAcpy = VA.template cast<double>();
+  Eigen::MatrixXi FAcpy = FA.template cast<int>();
+  Eigen::MatrixXd VBcpy = VB.template cast<double>();
+  Eigen::MatrixXi FBcpy = FB.template cast<int>();
+
+  Eigen::MatrixXd VVABcpy;
+  Eigen::MatrixXi FFABcpy;
+  Eigen::VectorXi  JABcpy;
+  Eigen::VectorXi IMABcpy;
+  Eigen::MatrixXi IFcpy;
+  igl::copyleft::cgal::RemeshSelfIntersectionsParam params;
+  params.detect_only = detect_only;
+  params.first_only = first_only;
+  params.stitch_all = stitch_all;
+  //params.slow_and_more_precise_rounding = slow_and_more_precise_rounding;
+  igl::copyleft::cgal::intersect_other(
+    VAcpy,FAcpy,VBcpy,FBcpy,params,IFcpy,VVABcpy,FFABcpy,JABcpy,IMABcpy);
+
+  EigenDenseLike<npe_Matrix_FA> IF   =   IFcpy.cast<typename decltype(IF  )::Scalar>();
+  EigenDenseLike<npe_Matrix_VA> VVAB = VVABcpy.cast<typename decltype(VVAB)::Scalar>();
+  EigenDenseLike<npe_Matrix_FA> FFAB = FFABcpy.cast<typename decltype(FFAB)::Scalar>();
+  EigenDenseLike<npe_Matrix_FA>  JAB =  JABcpy.cast<typename decltype( JAB)::Scalar>();
+  EigenDenseLike<npe_Matrix_FA> IMAB = IMABcpy.cast<typename decltype(IMAB)::Scalar>();
+  return std::make_tuple(
+    npe::move(IF), 
+    npe::move(VVAB), 
+    npe::move(FFAB), 
+    npe::move( JAB), 
+    npe::move(IMAB));
+npe_end_code()
+
+

--- a/src/copyleft/cgal/mesh_boolean.cpp
+++ b/src/copyleft/cgal/mesh_boolean.cpp
@@ -1,0 +1,63 @@
+#include <npe.h>
+#include <typedefs.h>
+#include <igl/copyleft/cgal/mesh_boolean.h>
+
+
+const char* ds_mesh_boolean = R"igl_Qu8mg5v7(
+MESH_BOOLEAN Compute boolean csg operations on "solid", consistently oriented
+meshes.
+      
+
+Parameters
+----------
+VA  : #VA by 3 list of vertex positions of first mesh
+FA  : #FA by 3 list of triangle indices into VA
+VB  : #VB by 3 list of vertex positions of second mesh
+FB  : #FB by 3 list of triangle indices into VB
+
+Returns
+-------
+VC : #VC by 3 list of vertex positions of boolean result mesh
+FC : #FC by 3 list of triangle indices into VC
+J  : #FC list of indices into [FA;FA.rows()+FB] revealing "birth" facet
+      
+See also
+--------
+mesh_boolean_cork, intersect_other, remesh_self_intersections
+)igl_Qu8mg5v7";
+
+npe_function(mesh_boolean)
+npe_doc(ds_mesh_boolean)
+
+npe_arg(va, dense_float, dense_double)
+npe_arg(fa, dense_int, dense_long, dense_longlong)
+npe_arg(vb, npe_matches(va))
+npe_arg(fb, npe_matches(fa))
+npe_arg(type, std::string)
+
+
+npe_begin_code()
+  Eigen::MatrixXd va_copy = va.template cast<double>();
+  Eigen::MatrixXd vb_copy = vb.template cast<double>();
+  Eigen::MatrixXi fa_copy = fa.template cast<int>();
+  Eigen::MatrixXi fb_copy = fb.template cast<int>();
+
+  Eigen::MatrixXd vc_copy;
+  Eigen::MatrixXi fc_copy;
+  Eigen::VectorXi  j_copy;
+  igl::copyleft::cgal::mesh_boolean(
+    va_copy, 
+    fa_copy,
+    vb_copy,
+    fb_copy,
+    type,
+    vc_copy,
+    fc_copy,
+     j_copy);
+
+  EigenDenseLike<npe_Matrix_va> vc = vc_copy.cast<typename decltype(vc)::Scalar>();
+  EigenDenseLike<npe_Matrix_fa> fc = fc_copy.cast<typename decltype(fc)::Scalar>();
+  EigenDenseLike<npe_Matrix_fa>  j =  j_copy.cast<typename decltype( j)::Scalar>();
+  return std::make_tuple(npe::move(vc), npe::move(fc), npe::move(j));
+npe_end_code()
+

--- a/src/copyleft/cgal/remesh_self_intersections.cpp
+++ b/src/copyleft/cgal/remesh_self_intersections.cpp
@@ -1,0 +1,79 @@
+#include <npe.h>
+#include <typedefs.h>
+#include <igl/copyleft/cgal/remesh_self_intersections.h>
+
+
+
+const char* ds_remesh_self_intersections = R"igl_Qu8mg5v7(
+REMESH_SELF_INTERSECTIONS Given a triangle mesh (V,F) compute a new mesh (VV,FF)
+which is the same as (V,F) except that any self-intersecting triangles in (V,F)
+have been subdivided (new vertices and face created) so that the
+self-intersection contour lies exactly on edges in (VV,FF). New vertices will
+appear in original faces or on original edges. New vertices on edges are
+"merged" only across original faces sharing that edge. This means that if the
+input triangle mesh is a closed manifold the output will be too.
+      
+
+Parameters
+----------
+V  : #V by 3 list of vertex positions of mesh
+F  : #F by 3 list of triangle indices into rows of V
+detect_only : avoid constructing intersections results when possible  {false}
+first_only  : return after detecting the first intersection (if
+  first_only==true, then detect_only should also be true) {false}
+stitch_all  : whether to stitch all resulting constructed elements into a
+  (non-manifold) mesh  {false}
+slow_and_more_precise_rounding  : whether to use slow and more precise
+  rounding (see assign_scalar) {false}
+
+
+Returns
+-------
+VV : #VV by 3 list of vertex positions
+FF : #FF by 3 list of triangle indices into VV
+IF : #intersecting face pairs by 2  list of intersecting face pairs, indexing F
+J  : #FF list of indices into F denoting birth triangle
+IM : #VV list of indices into VV of unique vertices.
+      
+See also
+--------
+mesh_boolean
+)igl_Qu8mg5v7";
+
+npe_function(remesh_self_intersections)
+npe_doc(ds_remesh_self_intersections)
+
+npe_arg(V, dense_float, dense_double)
+npe_arg(F, dense_int, dense_long, dense_longlong)
+npe_default_arg(detect_only, bool, false)
+npe_default_arg(first_only, bool, false)
+npe_default_arg(stitch_all, bool, false)
+// Awaiting bump in libigl
+//npe_default_arg(slow_and_more_precise_rounding, bool, false)
+
+
+npe_begin_code()
+  Eigen::MatrixXd Vcpy = V.template cast<double>();
+  Eigen::MatrixXi Fcpy = F.template cast<int>();
+
+  Eigen::MatrixXd VVcpy;
+  Eigen::MatrixXi FFcpy;
+  Eigen::VectorXi  Jcpy;
+  Eigen::VectorXi IMcpy;
+  Eigen::MatrixXi IFcpy;
+  igl::copyleft::cgal::RemeshSelfIntersectionsParam params;
+  params.detect_only = detect_only;
+  params.first_only = first_only;
+  params.stitch_all = stitch_all;
+  //params.slow_and_more_precise_rounding = slow_and_more_precise_rounding;
+  igl::copyleft::cgal::remesh_self_intersections(
+    Vcpy,Fcpy,params,VVcpy,FFcpy,IFcpy,Jcpy,IMcpy);
+
+  EigenDenseLike<npe_Matrix_V> VV = VVcpy.cast<typename decltype(VV)::Scalar>();
+  EigenDenseLike<npe_Matrix_F> FF = FFcpy.cast<typename decltype(FF)::Scalar>();
+  EigenDenseLike<npe_Matrix_F> IF = IFcpy.cast<typename decltype(IF)::Scalar>();
+  EigenDenseLike<npe_Matrix_F>  J =  Jcpy.cast<typename decltype( J)::Scalar>();
+  EigenDenseLike<npe_Matrix_F> IM = IMcpy.cast<typename decltype(IM)::Scalar>();
+  return std::make_tuple(npe::move(VV), npe::move(FF), npe::move(IF), npe::move(J), npe::move(IM));
+npe_end_code()
+


### PR DESCRIPTION
This is a work in progress that for now shows a proof of concept of adding igl::copyleft::cgal::convex_hull to the python bindings.

This PR might get fleshed out with all the cgal functions or it might get superseded by a PR that adds all the igl module functions.

I'm curious whether there's a nice way to make this binding show up as something like `igl.copyleft.cgal.convex_hull` rather than (currently) `igl.convex_hull`. Any suggestions ?
