### PR TITLE
fit cubic bezier

### DIFF
--- a/src/fit_cubic_bezier.cpp
+++ b/src/fit_cubic_bezier.cpp
@@ -1,0 +1,39 @@
+#include <npe.h>
+#include <common.h>
+#include <typedefs.h>
+#include <igl/fit_cubic_bezier.h>
+
+const char *ds_fit_cubic_bezier = R"igl_Qu8mg5v7(
+Fit a cubic bezier spline (G1 continuous) to an ordered list of input
+points in any dimension, according to "An algorithm for automatically
+fitting digitized curves" [Schneider 1990].
+
+Parameters
+----------
+  d  #d by dim list of points along a curve to be fit with a cubic bezier
+    spline (should probably be roughly uniformly spaced). If d(0)==d(end),
+    then will treat as a closed curve.
+  error  maximum squared distance allowed
+Returns
+-------
+  cubics #cubics list of 4 by dim lists of cubic control points
+
+)igl_Qu8mg5v7";
+
+npe_function(fit_cubic_bezier)
+npe_doc(ds_fit_cubic_bezier)
+
+npe_arg(d, dense_float, dense_double)
+npe_arg(error, double)
+
+npe_begin_code()
+  // igl::fit_cubic_bezier is hard-coded to double, so for now copy.
+  Eigen::MatrixXd d_cpy = d.template cast<double>();
+  std::vector<Eigen::MatrixXd> c_cpy;
+  igl::fit_cubic_bezier(d_cpy,error,c_cpy);
+  std::vector<EigenDenseLike<npe_Matrix_d>> c(c_cpy.size());
+  std::transform (c_cpy.begin(), c_cpy.end(), c.begin(),
+      [](const Eigen::MatrixXd & ci){ return ci.cast<npe_Scalar_d>();});
+  return pybind11::detail::type_caster<decltype(c)>::cast(c, pybind11::return_value_policy::move, pybind11::none());
+npe_end_code()
+

--- a/src/fit_cubic_bezier.cpp
+++ b/src/fit_cubic_bezier.cpp
@@ -2,6 +2,9 @@
 #include <common.h>
 #include <typedefs.h>
 #include <igl/fit_cubic_bezier.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
+
 
 const char *ds_fit_cubic_bezier = R"igl_Qu8mg5v7(
 Fit a cubic bezier spline (G1 continuous) to an ordered list of input
@@ -34,6 +37,9 @@ npe_begin_code()
   std::vector<EigenDenseLike<npe_Matrix_d>> c(c_cpy.size());
   std::transform (c_cpy.begin(), c_cpy.end(), c.begin(),
       [](const Eigen::MatrixXd & ci){ return ci.cast<npe_Scalar_d>();});
+  // numpyeigen's pybind11 fork `numpy_hacks_stable` is printing "Encapsulate move!"
+  // https://github.com/fwilliams/numpyeigen/issues/58
   return pybind11::detail::type_caster<decltype(c)>::cast(c, pybind11::return_value_policy::move, pybind11::none());
+
 npe_end_code()
 


### PR DESCRIPTION
Add the missing wrapper for `igl::fit_cubic_bezier`

The libigl function hard codes MatrixXd and doubles. So for now this needs to copy

AFAIK, Eigen's ND array support is still unstable, hence the libigl function outputs a std::vector<> of (same sized) matrices. In numpy, we'd probably rather have an nd array directly. For now, this wrapper matches the c++ output.

Meanwhile, numpyeigen's `numpy_hacks_stable` fork of pybind11 is spitting out some complaints to cerr. The output looks fine, but it'd be nicer to keep it quiet.