### PR TITLE
Fix incorrect error message in assert functions

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -218,7 +218,7 @@ void assert_valid_3d_tri_mesh(const TV& v, const TF& f, std::string v_name="v", 
                                     ".shape = [" + std::to_string(v.rows()) + ", " + std::to_string(v.cols()) + "]");
     }
     if (f.cols() != 3) {
-        throw pybind11::value_error("Invalid mesh faces, " + f_name + " must have shape [#faces, 4] but got " + f_name +
+        throw pybind11::value_error("Invalid mesh faces, " + f_name + " must have shape [#faces, 3] but got " + f_name +
                                     ".shape = [" + std::to_string(f.rows()) + ", " + std::to_string(f.cols()) + "]");
     }
 }
@@ -265,7 +265,7 @@ void assert_valid_23d_tri_mesh(const TV &v, const TF &f, std::string v_name = "v
     }
     if (f.cols() != 3)
     {
-        throw pybind11::value_error("Invalid mesh faces, " + f_name + " must have shape [#faces, 4] but got " + f_name +
+        throw pybind11::value_error("Invalid mesh faces, " + f_name + " must have shape [#faces, 3] but got " + f_name +
                                     ".shape = [" + std::to_string(f.rows()) + ", " + std::to_string(f.cols()) + "]");
     }
 }


### PR DESCRIPTION
When I install the package from source code and run my program, I got this error message,
```
ValueError: Invalid mesh faces, f must have shape [#faces, 4] but got f.shape = [24459, 4]
```
which confused me a lot, then later found that there are some typos in the source code assert functions.