### PR TITLE
Direct delta mush python binding

### DIFF
--- a/src/direct_delta_mush.cpp
+++ b/src/direct_delta_mush.cpp
@@ -1,0 +1,120 @@
+#include <common.h>
+#include <npe.h>
+#include <typedefs.h>
+#include <igl/direct_delta_mush.h>
+
+const char* ds_direct_delta_mush = R"igl_Qu8mg5v7(
+Perform Direct Delta Mush Skinning. 
+Computes Direct Delta Mesh Skinning (Variant 0) from 
+"Direct Delta Mush Skinning and Variants"
+
+Parameters
+----------
+v  #V by 3 list of rest pose vertex positions
+e  #E Number of bones
+t  #E*4 by 3 list of bone pose transformations
+omega #V by #E*10 list of precomputated matrix values
+
+Returns
+-------
+u  #V by 3 list of output vertex positions
+
+See also
+--------
+
+
+Notes
+-----
+None
+
+Examples
+--------
+)igl_Qu8mg5v7";
+
+npe_function(direct_delta_mush)
+npe_doc(ds_direct_delta_mush)
+
+npe_arg(v, dense_float, dense_double)
+npe_arg(t, dense_float, dense_double)
+npe_arg(omega, dense_float, dense_double)
+
+npe_begin_code()
+  assert_cols_equals(v, 3, "v");
+  assert_valid_bone_transforms(t, "t");
+  assert_rows_equals(t, (omega.cols() * 4) / 10, "t");
+
+  Eigen::MatrixXd v_copy = v.template cast<double>();
+  Eigen::MatrixXd t_copy = t.template cast<double>();
+  Eigen::MatrixXd omega_copy = omega.template cast<double>();
+
+  std::vector<Eigen::Affine3d, Eigen::aligned_allocator<Eigen::Affine3d>> 
+      t_affine(t_copy.rows() / 4);
+  
+  for(int bone = 0; bone < t_copy.rows(); bone += 4)
+  {
+    Eigen::Matrix4d t_bone;
+    t_bone << t_copy.block(bone, 0, 4, 3).transpose(), 0.0, 0.0, 0.0, 0.0;
+    Eigen::Affine3d a_bone;
+    a_bone.matrix() = t_bone;
+
+    t_affine[bone] = a_bone;
+  }
+
+  Eigen::MatrixXd u;
+  igl::direct_delta_mush(v_copy, t_affine, omega_copy, u);
+  return npe::move(u);
+
+npe_end_code()
+
+const char* ds_direct_delta_mush_precomp = R"igl_Qu8mg5v7(
+Do the Omega precomputation necessary for Direct Delta Mush Skinning.
+
+Parameters
+----------
+v  #V by 3 list of rest pose vertex positions
+f  #F by 3 list of triangle indices into rows of V
+w  #V by #Edges list of weights
+p  number of smoothing iterations
+lambda  rotation smoothing step size
+kappa   translation smoothness step size
+alpha   translation smoothness blending weight
+
+Returns
+-------
+omega : #V by #E*10 list of precomputated matrix values
+
+See also
+--------
+
+
+Notes
+-----
+None
+
+Examples
+--------
+)igl_Qu8mg5v7";
+
+npe_function(direct_delta_mush_precomputation)
+npe_doc(ds_direct_delta_mush_precomp)
+
+npe_arg(v, dense_float, dense_double)
+npe_arg(f, dense_int, dense_long, dense_longlong)
+npe_arg(w, npe_matches(v))
+npe_arg(p, int)
+npe_arg(lambda, double)
+npe_arg(kappa, double)
+npe_arg(alpha, double)
+
+npe_begin_code()
+  assert_valid_3d_tri_mesh(v, f);
+
+  Eigen::MatrixXd v_copy = v.template cast<double>();
+  Eigen::MatrixXd w_copy = w.template cast<double>();
+  Eigen::MatrixXi f_copy = f.template cast<int>();
+
+  Eigen::MatrixXd omega;
+  igl::direct_delta_mush_precomputation(v_copy, f_copy, w_copy, p, lambda, kappa, alpha, omega);
+  return npe::move(omega);
+  
+npe_end_code()

--- a/src/direct_delta_mush.cpp
+++ b/src/direct_delta_mush.cpp
@@ -50,10 +50,11 @@ npe_begin_code()
   std::vector<Eigen::Affine3d, Eigen::aligned_allocator<Eigen::Affine3d>> 
       t_affine(t_copy.rows() / 4);
   
-  for(int bone = 0; bone < t_copy.rows(); bone += 4)
+  for(int bone = 0; bone < t_affine.size(); ++bone)
   {
     Eigen::Matrix4d t_bone;
-    t_bone << t_copy.block(bone, 0, 4, 3).transpose(), 0.0, 0.0, 0.0, 0.0;
+    t_bone << t_copy.block(bone * 4, 0, 4, 3).transpose(), 0.0, 0.0, 0.0, 0.0;
+    
     Eigen::Affine3d a_bone;
     a_bone.matrix() = t_bone;
 

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -311,3 +311,21 @@ void assert_valid_2d_tri_mesh(const TV& v, const TF& f, std::string v_name="v", 
                                     ".shape = [" + std::to_string(f.rows()) + ", " + std::to_string(f.cols()) + "]");
     }
 }
+
+template <typename TV>
+void assert_valid_bone_transforms(const TV& t, std::string t_name="t") {
+    if (t.rows() <= 0) {
+        throw pybind11::value_error("Invalid number of transforms, " + t_name + " has zero rows (" + t_name +
+                                    ".shape = [" + std::to_string(t.rows()) + ", " + std::to_string(t.cols()) + "]) ");
+    }
+    
+    if (t.cols() != 3) {
+        throw pybind11::value_error("Invalid number of cols in transforms, " + t_name + " must have shape [#bones * 4, 3] but got " + t_name +
+                                    ".shape = [" + std::to_string(t.rows()) + ", " + std::to_string(t.cols()) + "]");
+    }
+
+    if (t.rows() % 4 != 0) {
+        throw pybind11::value_error("Invalid number of rows in transforms, " + t_name + " must have shape [#bones * 4, 3] but got " + t_name +
+                                    ".shape = [" + std::to_string(t.rows()) + ", " + std::to_string(t.cols()) + "].");   
+    }
+}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -756,7 +756,7 @@ class TestBasic(unittest.TestCase):
         V,F = igl.marching_cubes(sphereField, pts, n, n, n, 0.0)
 
         self.assertTrue(V.dtype == pts.dtype)
-        self.assertTrue(F.dtype == np.int)
+        self.assertTrue(F.dtype == np.int64)
 
         self.assertNotEqual(V.shape, (0,3))
         self.assertNotEqual(F.shape, (0,3))
@@ -1724,8 +1724,8 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(np.allclose(e2, r2))
         self.assertTrue(e1.flags.c_contiguous)
         self.assertTrue(e2.flags.c_contiguous)
-        self.assertTrue(e1.dtype == np.int)
-        self.assertTrue(e2.dtype == np.int)
+        self.assertTrue(e1.dtype == np.int64)
+        self.assertTrue(e2.dtype == np.int64)
 
     def test_exterior_edges(self):
         e = igl.exterior_edges(self.f1)
@@ -2287,9 +2287,9 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(q.shape == (2*2, 4))
         self.assertTrue(v.flags.c_contiguous)
         self.assertTrue(q.flags.c_contiguous)
-        self.assertTrue(v.dtype == np.float)
-        self.assertTrue(q.dtype == np.int)
-        self.assertTrue(e.dtype == np.int)
+        self.assertTrue(v.dtype == np.float64)
+        self.assertTrue(q.dtype == np.int64)
+        self.assertTrue(e.dtype == np.int64)
 
     def test_sparse_voxel_grid(self):
         def sphere1(point):
@@ -2297,10 +2297,10 @@ class TestBasic(unittest.TestCase):
         point = np.array([1.0, 0.0, 0.0])
         cs, cv, ci = igl.sparse_voxel_grid(point, sphere1, 1.0, 100)
         self.assertTrue(cv.flags.c_contiguous)
-        self.assertTrue(cv.dtype == np.float)
+        self.assertTrue(cv.dtype == np.float64)
         self.assertTrue(cv.shape == (len(cs), 3))
         self.assertTrue(ci.flags.c_contiguous)
-        self.assertTrue(ci.dtype == np.int)
+        self.assertTrue(ci.dtype == np.int64)
         self.assertTrue(ci.shape[1] == 8)
 
     def test_topological_hole_fill(self):
@@ -2310,7 +2310,7 @@ class TestBasic(unittest.TestCase):
         ff = igl.topological_hole_fill(f, b, h)
         self.assertTrue(ff.flags.c_contiguous)
         self.assertTrue(ff.shape[1] == 3)
-        self.assertTrue(ff.dtype == np.int)
+        self.assertTrue(ff.dtype == np.int64)
         self.assertTrue(ff.shape[0] != f.shape[0])
 
     def test_triangulated_grid(self):
@@ -2319,8 +2319,8 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(f.shape == (162, 3))
         self.assertTrue(f.flags.c_contiguous)
         self.assertTrue(v.flags.c_contiguous)
-        self.assertTrue(v.dtype == np.float)
-        self.assertTrue(f.dtype == np.int)
+        self.assertTrue(v.dtype == np.float64)
+        self.assertTrue(f.dtype == np.int64)
 
     def test_unproject_on_line(self):
         pos = np.array([10., 10.])
@@ -2332,7 +2332,7 @@ class TestBasic(unittest.TestCase):
 
         self.assertTrue(z.flags.c_contiguous)
         self.assertTrue(z.shape == (3, ))
-        self.assertTrue(z.dtype == np.float)
+        self.assertTrue(z.dtype == np.float64)
 
     def test_unproject_on_plane(self):
         pos = np.array([10., 10.])
@@ -2343,7 +2343,7 @@ class TestBasic(unittest.TestCase):
 
         self.assertTrue(z.flags.c_contiguous)
         self.assertTrue(z.shape == (3, ))
-        self.assertTrue(z.dtype == np.float)
+        self.assertTrue(z.dtype == np.float64)
 
     def test_fast_winding_number_for_points(self):
         xs = np.linspace(-5.0, 5.0, 10)
@@ -2355,7 +2355,7 @@ class TestBasic(unittest.TestCase):
         wn = igl.fast_winding_number_for_points(self.v1, n, a, grid)
         self.assertTrue(wn.flags.c_contiguous)
         self.assertTrue(wn.shape == (grid.shape[0], ))
-        self.assertTrue(wn.dtype == np.float)
+        self.assertTrue(wn.dtype == np.float64)
 
     def test_fast_winding_number_for_meshes(self):
         xs = np.linspace(-5.0, 5.0, 10)
@@ -2365,7 +2365,7 @@ class TestBasic(unittest.TestCase):
         wn = igl.fast_winding_number_for_meshes(self.v1, self.f1, grid)
         self.assertTrue(wn.flags.c_contiguous)
         self.assertTrue(wn.shape == (grid.shape[0], ))
-        self.assertTrue(wn.dtype == np.float)
+        self.assertTrue(wn.dtype == np.float64)
 
     def test_flip_avoiding_line_search(self):
         def fun(v):
@@ -2387,7 +2387,7 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(ef.flags.c_contiguous)
         self.assertTrue(ei.flags.c_contiguous)
         self.assertTrue(e.dtype == emap.dtype ==
-                        ef.dtype == ei.dtype == np.int)
+                        ef.dtype == ei.dtype == np.int64)
 
     def test_circulation(self):
         pass

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1528,6 +1528,38 @@ class TestBasic(unittest.TestCase):
         self.assertTrue(M.shape[0] == V.shape[0])
         self.assertTrue(M.shape[1] == W.shape[1]*4)
 
+    def test_direct_delta_mush(self):
+        V, F = igl.read_triangle_mesh(os.path.join(self.test_path, "arm.obj"))
+        W = igl.read_dmat(os.path.join(self.test_path, "arm-weights.dmat"))
+        _, BE, _, _, _, _ = igl.read_tgf(os.path.join(self.test_path, "arm.tgf"))
+
+        # Use same values as tutorial
+        # https://github.com/libigl/libigl/blob/main/tutorial/408_DirectDeltaMush/main.cpp
+        p = 20
+        l = 3
+        k = 1
+        a = 0.8
+        omega = igl.direct_delta_mush_precomputation(V, F,W, p, l, k, a)
+
+        self.assertTrue(omega.shape[0] == V.shape[0])
+        self.assertTrue(omega.shape[1] == BE.shape[0] * 10)
+
+        T = np.zeros((BE.shape[0]*4, 3))
+        I = np.eye(3)
+        for i in range(0, T.shape[0], 4):
+            T[i:i+3, :] = I
+
+        U = igl.direct_delta_mush(V, T, omega)
+
+        self.assertTrue(U.shape[0] == V.shape[0])
+        self.assertTrue(U.shape[1] == 3)
+        self.assertTrue(U.dtype == V.dtype)
+    
+    def test_direct_delta_mush_precomputation(self):
+        # covered in test_direct_delta_mush
+        pass
+
+
     def test_point_mesh_squared_distance(self):
         dist, i, c = igl.point_mesh_squared_distance(
             np.array([0., 0., 0.]), self.v1, self.f1)


### PR DESCRIPTION
### Expose Direct Delta Mush Skinning to Python

Libigl-python currently doesn't support direct delta mush skinning. The set of commits in this branch allows for this support. Both the precomputation and delta mush skinning are exposed through the **direct_delta_mush.cpp** binding source and are tested in **test_direct_delta_mush** function of the tests/test_basic.py file.

Additionally I fixed a few tests (830880d8d6dcdacd4f4a4f17527034dcbc33977d) by pointing the tests to the correct numpy datatypes. These checks seemed to be failing the tests and I wanted to have a good starting point before adding the direct delta mush skinning test.

## Platform Notes
I tested all my changes on the following configuration

OS: Ubuntu 22.04.1 LTS
Type: 64 Bit
Processor: Intel® Core™ i7-9750H CPU @ 2.60GHz × 12
Memory: 16 GB
Graphics: NVIDIA Corporation TU116M [GeForce GTX 1660 Ti Mobile]
Graphics Memory: 6 GB
Driver Version: 515.86.01
CUDA Version: 11.7
