### PR TITLE
increase j2->j8 ; allow env override MAX_JOBS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,11 @@ class CMakeBuild(build_ext):
                 if sys.maxsize > 2**32:
                     cmake_args += ['-A', 'x64']
                 # build_args += ['--', '/m']
-        else:
-            build_args += ['--', '-j2']
+        else: 
+            if "MAX_JOBS" in os.environ:
+                build_args += ['--', f"-j{os.environ['MAX_JOBS']}"]
+            else:
+                build_args += ['--', '-j8']
 
 
         tmp = os.environ.get("AR", "")


### PR DESCRIPTION
The default for parallel build was previous 2 cores. I've increased to 8 (I believe this will better match the common case). Meanwhile, I added a param via environment variables to change as needed (mirroring how pytorch controls this). Anyone can do:

```
MAX_JOBS=64 python setup.py install
```