### PR TITLE
License and copyright headers

### DIFF
--- a/LICENSE.GPL
+++ b/LICENSE.GPL
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/LICENSE.MPL2
+++ b/LICENSE.MPL2
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ PYTHONPATH=. python tests/test_basic.py
 
 ## License
 
-Like libigl, the wrapper source code is licensed under MPL2. Code in the
-copyleft and restricted sub-directories may have more restrictive licenses.
+Like libigl, the wrapper source code is licensed under MPL2. Code included via
+the copyleft and restricted sub-directories may have more restrictive licenses.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ and if developing and trying to run from this directory. You could use:
 PYTHONPATH=. python tests/test_basic.py
 ```
 
+## License
+
+Like libigl, the wrapper source code is licensed under MPL2. Code in the
+copyleft and restricted sub-directories may have more restrictive licenses.

--- a/igl/__init__.py
+++ b/igl/__init__.py
@@ -1,3 +1,10 @@
+# This file is part of libigl, a simple c++ geometry processing library.
+#
+# Copyright (C) 2023 Alec Jacobson
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
 from .pyigl import *
 from .helpers import *
 from .pyigl_classes import *

--- a/igl/_version.py
+++ b/igl/_version.py
@@ -1,1 +1,8 @@
-__version__ = "2.5.3dev"
+# This file is part of libigl, a simple c++ geometry processing library.
+#
+# Copyright (C) 2023 Alec Jacobson
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+__version__ = "2.5.4dev"

--- a/src/active_set.cpp
+++ b/src/active_set.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/active_set.cpp
+++ b/src/active_set.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/adjacency_list.cpp
+++ b/src/adjacency_list.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <igl/adjacency_list.h>

--- a/src/adjacency_list.cpp
+++ b/src/adjacency_list.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <igl/adjacency_list.h>

--- a/src/adjacency_matrix.cpp
+++ b/src/adjacency_matrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -48,5 +55,3 @@ npe_begin_code()
   return npe::move(a);
 
 npe_end_code()
-
-

--- a/src/adjacency_matrix.cpp
+++ b/src/adjacency_matrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -55,3 +48,5 @@ npe_begin_code()
   return npe::move(a);
 
 npe_end_code()
+
+

--- a/src/adjacency_matrix.cpp
+++ b/src/adjacency_matrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/all_pairs_distances.cpp
+++ b/src/all_pairs_distances.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -59,3 +52,5 @@ npe_begin_code()
   return npe::move(D);
 
 npe_end_code()
+
+

--- a/src/all_pairs_distances.cpp
+++ b/src/all_pairs_distances.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -52,5 +59,3 @@ npe_begin_code()
   return npe::move(D);
 
 npe_end_code()
-
-

--- a/src/all_pairs_distances.cpp
+++ b/src/all_pairs_distances.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/ambient_occlusion.cpp
+++ b/src/ambient_occlusion.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __missing miss the rest two functions with AABB and shoot_ray. __example
 
 #include <common.h>

--- a/src/ambient_occlusion.cpp
+++ b/src/ambient_occlusion.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __missing miss the rest two functions with AABB and shoot_ray. __example
 
 #include <common.h>

--- a/src/arap_linear_block.cpp
+++ b/src/arap_linear_block.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <string>

--- a/src/arap_linear_block.cpp
+++ b/src/arap_linear_block.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <string>

--- a/src/arap_rhs.cpp
+++ b/src/arap_rhs.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/arap_rhs.cpp
+++ b/src/arap_rhs.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -73,3 +66,5 @@ npe_begin_code()
   return npe::move(k);
 
 npe_end_code()
+
+

--- a/src/arap_rhs.cpp
+++ b/src/arap_rhs.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -66,5 +73,3 @@ npe_begin_code()
   return npe::move(k);
 
 npe_end_code()
-
-

--- a/src/average_onto_faces.cpp
+++ b/src/average_onto_faces.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -54,3 +47,4 @@ npe_begin_code()
   return npe::move(SF);
 
 npe_end_code()
+

--- a/src/average_onto_faces.cpp
+++ b/src/average_onto_faces.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -47,4 +54,3 @@ npe_begin_code()
   return npe::move(SF);
 
 npe_end_code()
-

--- a/src/average_onto_faces.cpp
+++ b/src/average_onto_faces.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/average_onto_vertices.cpp
+++ b/src/average_onto_vertices.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/average_onto_vertices.cpp
+++ b/src/average_onto_vertices.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -48,3 +41,5 @@ npe_begin_code()
   return npe::move(sv);
 
 npe_end_code()
+
+

--- a/src/average_onto_vertices.cpp
+++ b/src/average_onto_vertices.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -41,5 +48,3 @@ npe_begin_code()
   return npe::move(sv);
 
 npe_end_code()
-
-

--- a/src/avg_edge_length.cpp
+++ b/src/avg_edge_length.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <igl/avg_edge_length.h>
@@ -45,3 +38,5 @@ npe_begin_code()
   return igl::avg_edge_length(v, f);
 
 npe_end_code()
+
+

--- a/src/avg_edge_length.cpp
+++ b/src/avg_edge_length.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <igl/avg_edge_length.h>
@@ -38,5 +45,3 @@ npe_begin_code()
   return igl::avg_edge_length(v, f);
 
 npe_end_code()
-
-

--- a/src/avg_edge_length.cpp
+++ b/src/avg_edge_length.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <igl/avg_edge_length.h>

--- a/src/barycenter.cpp
+++ b/src/barycenter.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -47,3 +40,5 @@ npe_begin_code()
   return npe::move(bc);
 
 npe_end_code()
+
+

--- a/src/barycenter.cpp
+++ b/src/barycenter.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/barycenter.cpp
+++ b/src/barycenter.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -40,5 +47,3 @@ npe_begin_code()
   return npe::move(bc);
 
 npe_end_code()
-
-

--- a/src/barycentric_coordinates.cpp
+++ b/src/barycentric_coordinates.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/barycentric_coordinates.cpp
+++ b/src/barycentric_coordinates.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/bfs.cpp
+++ b/src/bfs.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/bfs.cpp
+++ b/src/bfs.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -60,6 +67,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(d), npe::move(p));
 
 npe_end_code()
-
-
-

--- a/src/bfs.cpp
+++ b/src/bfs.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -67,3 +60,6 @@ npe_begin_code()
   return std::make_tuple(npe::move(d), npe::move(p));
 
 npe_end_code()
+
+
+

--- a/src/bfs_orient.cpp
+++ b/src/bfs_orient.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/bfs_orient.cpp
+++ b/src/bfs_orient.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/biharmonic_coordinates.cpp
+++ b/src/biharmonic_coordinates.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/biharmonic_coordinates.cpp
+++ b/src/biharmonic_coordinates.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/bijective_composite_harmonic_mapping.cpp
+++ b/src/bijective_composite_harmonic_mapping.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -117,5 +124,3 @@ npe_begin_code()
   return std::make_pair(success, npe::move(u));
 
 npe_end_code()
-
-

--- a/src/bijective_composite_harmonic_mapping.cpp
+++ b/src/bijective_composite_harmonic_mapping.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -124,3 +117,5 @@ npe_begin_code()
   return std::make_pair(success, npe::move(u));
 
 npe_end_code()
+
+

--- a/src/bijective_composite_harmonic_mapping.cpp
+++ b/src/bijective_composite_harmonic_mapping.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/blue_noise.cpp
+++ b/src/blue_noise.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Peter Kulits
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/blue_noise.cpp
+++ b/src/blue_noise.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Peter Kulits
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/bone_parents.cpp
+++ b/src/bone_parents.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -46,3 +39,5 @@ npe_begin_code()
   return npe::move(p);
 
 npe_end_code()
+
+

--- a/src/bone_parents.cpp
+++ b/src/bone_parents.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -39,5 +46,3 @@ npe_begin_code()
   return npe::move(p);
 
 npe_end_code()
-
-

--- a/src/bone_parents.cpp
+++ b/src/bone_parents.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <npe.h>

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <npe.h>
@@ -101,3 +94,5 @@ npe_begin_code()
   return std::make_tuple(success, npe::move(b), npe::move(bc));
 
 npe_end_code()
+
+

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <npe.h>
@@ -94,5 +101,3 @@ npe_begin_code()
   return std::make_tuple(success, npe::move(b), npe::move(bc));
 
 npe_end_code()
-
-

--- a/src/boundary_facets.cpp
+++ b/src/boundary_facets.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/boundary_facets.cpp
+++ b/src/boundary_facets.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -39,4 +46,3 @@ npe_begin_code()
   return npe::move(f);
 
 npe_end_code()
-

--- a/src/boundary_facets.cpp
+++ b/src/boundary_facets.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -46,3 +39,4 @@ npe_begin_code()
   return npe::move(f);
 
 npe_end_code()
+

--- a/src/boundary_loop.cpp
+++ b/src/boundary_loop.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -85,3 +78,4 @@ npe_begin_code()
   return l;
 
 npe_end_code()
+

--- a/src/boundary_loop.cpp
+++ b/src/boundary_loop.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -78,4 +85,3 @@ npe_begin_code()
   return l;
 
 npe_end_code()
-

--- a/src/boundary_loop.cpp
+++ b/src/boundary_loop.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/bounding_box.cpp
+++ b/src/bounding_box.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/bounding_box.cpp
+++ b/src/bounding_box.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -79,3 +72,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(bv), npe::move(bf_row_major));
 
 npe_end_code()
+
+

--- a/src/bounding_box.cpp
+++ b/src/bounding_box.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -72,5 +79,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(bv), npe::move(bf_row_major));
 
 npe_end_code()
-
-

--- a/src/bounding_box_diagonal.cpp
+++ b/src/bounding_box_diagonal.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -56,3 +49,5 @@ npe_begin_code()
   return igl::bounding_box_diagonal(v_copy);
 
 npe_end_code()
+
+

--- a/src/bounding_box_diagonal.cpp
+++ b/src/bounding_box_diagonal.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/bounding_box_diagonal.cpp
+++ b/src/bounding_box_diagonal.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -49,5 +56,3 @@ npe_begin_code()
   return igl::bounding_box_diagonal(v_copy);
 
 npe_end_code()
-
-

--- a/src/circulation.cpp
+++ b/src/circulation.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 //difficult to test
 

--- a/src/circulation.cpp
+++ b/src/circulation.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 //difficult to test
 
@@ -76,3 +69,4 @@ npe_begin_code()
   return res;
 
 npe_end_code()
+

--- a/src/circulation.cpp
+++ b/src/circulation.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 //difficult to test
 
@@ -69,4 +76,3 @@ npe_begin_code()
   return res;
 
 npe_end_code()
-

--- a/src/circumradius.cpp
+++ b/src/circumradius.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/circumradius.cpp
+++ b/src/circumradius.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -46,5 +53,3 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
-
-

--- a/src/circumradius.cpp
+++ b/src/circumradius.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -53,3 +46,5 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
+
+

--- a/src/collapse_small_triangles.cpp
+++ b/src/collapse_small_triangles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/collapse_small_triangles.cpp
+++ b/src/collapse_small_triangles.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -71,3 +64,5 @@ npe_begin_code()
   return npe::move(ff_row_major);
 
 npe_end_code()
+
+

--- a/src/collapse_small_triangles.cpp
+++ b/src/collapse_small_triangles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -64,5 +71,3 @@ npe_begin_code()
   return npe::move(ff_row_major);
 
 npe_end_code()
-
-

--- a/src/comb_cross_field.cpp
+++ b/src/comb_cross_field.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -58,5 +65,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(pd1out), npe::move(pd2out));
 
 npe_end_code()
-
-

--- a/src/comb_cross_field.cpp
+++ b/src/comb_cross_field.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -65,3 +58,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(pd1out), npe::move(pd2out));
 
 npe_end_code()
+
+

--- a/src/comb_cross_field.cpp
+++ b/src/comb_cross_field.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/comb_frame_field.cpp
+++ b/src/comb_frame_field.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -72,5 +79,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(pd1_combed), npe::move(pd2_combed));
 
 npe_end_code()
-
-

--- a/src/comb_frame_field.cpp
+++ b/src/comb_frame_field.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -79,3 +72,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(pd1_combed), npe::move(pd2_combed));
 
 npe_end_code()
+
+

--- a/src/comb_frame_field.cpp
+++ b/src/comb_frame_field.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/comb_line_field.cpp
+++ b/src/comb_line_field.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -58,3 +51,5 @@ npe_begin_code()
   return npe::move(pd1out);
 
 npe_end_code()
+
+

--- a/src/comb_line_field.cpp
+++ b/src/comb_line_field.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,5 +58,3 @@ npe_begin_code()
   return npe::move(pd1out);
 
 npe_end_code()
-
-

--- a/src/comb_line_field.cpp
+++ b/src/comb_line_field.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/compute_frame_field_bisectors.cpp
+++ b/src/compute_frame_field_bisectors.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -135,3 +128,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(bis1), npe::move(bis2));
 
 npe_end_code()
+
+

--- a/src/compute_frame_field_bisectors.cpp
+++ b/src/compute_frame_field_bisectors.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -128,5 +135,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(bis1), npe::move(bis2));
 
 npe_end_code()
-
-

--- a/src/compute_frame_field_bisectors.cpp
+++ b/src/compute_frame_field_bisectors.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/connect_boundary_to_infinity.cpp
+++ b/src/connect_boundary_to_infinity.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/connect_boundary_to_infinity.cpp
+++ b/src/connect_boundary_to_infinity.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -133,5 +140,3 @@ npe_begin_code()
   return npe::move(fo);
 
 npe_end_code()
-
-

--- a/src/connect_boundary_to_infinity.cpp
+++ b/src/connect_boundary_to_infinity.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -140,3 +133,5 @@ npe_begin_code()
   return npe::move(fo);
 
 npe_end_code()
+
+

--- a/src/connected_components.cpp
+++ b/src/connected_components.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -49,5 +56,3 @@ npe_begin_code()
    return std::make_tuple(comps, npe::move(c), npe::move(k));
 
 npe_end_code()
-
-

--- a/src/connected_components.cpp
+++ b/src/connected_components.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -56,3 +49,5 @@ npe_begin_code()
    return std::make_tuple(comps, npe::move(c), npe::move(k));
 
 npe_end_code()
+
+

--- a/src/connected_components.cpp
+++ b/src/connected_components.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/copyleft/cgal/convex_hull.cpp
+++ b/src/copyleft/cgal/convex_hull.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 

--- a/src/copyleft/cgal/convex_hull.cpp
+++ b/src/copyleft/cgal/convex_hull.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 

--- a/src/copyleft/cgal/intersect_other.cpp
+++ b/src/copyleft/cgal/intersect_other.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/intersect_other.h>

--- a/src/copyleft/cgal/intersect_other.cpp
+++ b/src/copyleft/cgal/intersect_other.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/intersect_other.h>
@@ -90,3 +83,5 @@ npe_begin_code()
     npe::move( JAB), 
     npe::move(IMAB));
 npe_end_code()
+
+

--- a/src/copyleft/cgal/intersect_other.cpp
+++ b/src/copyleft/cgal/intersect_other.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/intersect_other.h>
@@ -83,5 +90,3 @@ npe_begin_code()
     npe::move( JAB), 
     npe::move(IMAB));
 npe_end_code()
-
-

--- a/src/copyleft/cgal/mesh_boolean.cpp
+++ b/src/copyleft/cgal/mesh_boolean.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/mesh_boolean.h>
@@ -60,4 +67,3 @@ npe_begin_code()
   EigenDenseLike<npe_Matrix_fa>  j =  j_copy.cast<typename decltype( j)::Scalar>();
   return std::make_tuple(npe::move(vc), npe::move(fc), npe::move(j));
 npe_end_code()
-

--- a/src/copyleft/cgal/mesh_boolean.cpp
+++ b/src/copyleft/cgal/mesh_boolean.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/mesh_boolean.h>
@@ -67,3 +60,4 @@ npe_begin_code()
   EigenDenseLike<npe_Matrix_fa>  j =  j_copy.cast<typename decltype( j)::Scalar>();
   return std::make_tuple(npe::move(vc), npe::move(fc), npe::move(j));
 npe_end_code()
+

--- a/src/copyleft/cgal/mesh_boolean.cpp
+++ b/src/copyleft/cgal/mesh_boolean.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/mesh_boolean.h>

--- a/src/copyleft/cgal/remesh_self_intersections.cpp
+++ b/src/copyleft/cgal/remesh_self_intersections.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/remesh_self_intersections.h>
@@ -83,3 +76,4 @@ npe_begin_code()
   EigenDenseLike<npe_Matrix_F> IM = IMcpy.cast<typename decltype(IM)::Scalar>();
   return std::make_tuple(npe::move(VV), npe::move(FF), npe::move(IF), npe::move(J), npe::move(IM));
 npe_end_code()
+

--- a/src/copyleft/cgal/remesh_self_intersections.cpp
+++ b/src/copyleft/cgal/remesh_self_intersections.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/remesh_self_intersections.h>
@@ -76,4 +83,3 @@ npe_begin_code()
   EigenDenseLike<npe_Matrix_F> IM = IMcpy.cast<typename decltype(IM)::Scalar>();
   return std::make_tuple(npe::move(VV), npe::move(FF), npe::move(IF), npe::move(J), npe::move(IM));
 npe_end_code()
-

--- a/src/copyleft/cgal/remesh_self_intersections.cpp
+++ b/src/copyleft/cgal/remesh_self_intersections.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/copyleft/cgal/remesh_self_intersections.h>

--- a/src/cotmatrix.cpp
+++ b/src/cotmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -45,5 +52,3 @@ npe_begin_code()
   return npe::move(l);
 
 npe_end_code()
-
-

--- a/src/cotmatrix.cpp
+++ b/src/cotmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/cotmatrix.cpp
+++ b/src/cotmatrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -52,3 +45,5 @@ npe_begin_code()
   return npe::move(l);
 
 npe_end_code()
+
+

--- a/src/cotmatrix_entries.cpp
+++ b/src/cotmatrix_entries.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/cotmatrix_entries.cpp
+++ b/src/cotmatrix_entries.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,5 +58,3 @@ npe_begin_code()
   return npe::move(c);
 
 npe_end_code()
-
-

--- a/src/cotmatrix_entries.cpp
+++ b/src/cotmatrix_entries.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -58,3 +51,5 @@ npe_begin_code()
   return npe::move(c);
 
 npe_end_code()
+
+

--- a/src/cotmatrix_intrinsic.cpp
+++ b/src/cotmatrix_intrinsic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/cotmatrix_intrinsic.cpp
+++ b/src/cotmatrix_intrinsic.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -58,3 +51,5 @@ npe_begin_code()
   return npe::move(mat);
 
 npe_end_code()
+
+

--- a/src/cotmatrix_intrinsic.cpp
+++ b/src/cotmatrix_intrinsic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -51,5 +58,3 @@ npe_begin_code()
   return npe::move(mat);
 
 npe_end_code()
-
-

--- a/src/cross_field_missmatch.cpp
+++ b/src/cross_field_missmatch.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -71,3 +64,5 @@ npe_begin_code()
   return npe::move(mismatch);
 
 npe_end_code()
+
+

--- a/src/cross_field_missmatch.cpp
+++ b/src/cross_field_missmatch.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -64,5 +71,3 @@ npe_begin_code()
   return npe::move(mismatch);
 
 npe_end_code()
-
-

--- a/src/cross_field_missmatch.cpp
+++ b/src/cross_field_missmatch.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/crouzeix_raviart_cotmatrix.cpp
+++ b/src/crouzeix_raviart_cotmatrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -112,3 +105,5 @@ npe_begin_code()
   return npe::move(l);
 
 npe_end_code()
+
+

--- a/src/crouzeix_raviart_cotmatrix.cpp
+++ b/src/crouzeix_raviart_cotmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -105,5 +112,3 @@ npe_begin_code()
   return npe::move(l);
 
 npe_end_code()
-
-

--- a/src/crouzeix_raviart_cotmatrix.cpp
+++ b/src/crouzeix_raviart_cotmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/crouzeix_raviart_massmatrix.cpp
+++ b/src/crouzeix_raviart_massmatrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // static assertion fail: YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY
 
 #include <common.h>
@@ -115,3 +108,5 @@ npe_begin_code()
   return npe::move(m);
 
 npe_end_code()
+
+

--- a/src/crouzeix_raviart_massmatrix.cpp
+++ b/src/crouzeix_raviart_massmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // static assertion fail: YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY
 
 #include <common.h>
@@ -108,5 +115,3 @@ npe_begin_code()
   return npe::move(m);
 
 npe_end_code()
-
-

--- a/src/crouzeix_raviart_massmatrix.cpp
+++ b/src/crouzeix_raviart_massmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // static assertion fail: YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY
 
 #include <common.h>

--- a/src/cut_mesh.cpp
+++ b/src/cut_mesh.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Francis Williams
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <igl/cut_mesh.h>
 #include <npe.h>

--- a/src/cut_mesh.cpp
+++ b/src/cut_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Francis Williams
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <igl/cut_mesh.h>
 #include <npe.h>

--- a/src/cut_mesh_from_singularities.cpp
+++ b/src/cut_mesh_from_singularities.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Francis Williams
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/cut_mesh_from_singularities.cpp
+++ b/src/cut_mesh_from_singularities.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Francis Williams
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/cut_to_disk.cpp
+++ b/src/cut_to_disk.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/cut_to_disk.cpp
+++ b/src/cut_to_disk.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/cylinder.cpp
+++ b/src/cylinder.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/cylinder.cpp
+++ b/src/cylinder.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -50,5 +57,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(v_row_major), npe::move(f_row_major));
 
 npe_end_code()
-
-

--- a/src/cylinder.cpp
+++ b/src/cylinder.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -57,3 +50,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(v_row_major), npe::move(f_row_major));
 
 npe_end_code()
+
+

--- a/src/decimate.cpp
+++ b/src/decimate.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss 4 functions
 
 #include <common.h>
@@ -78,3 +71,5 @@ npe_begin_code()
   return std::make_tuple(reach, npe::move(u_row_major), npe::move(g_row_major), npe::move(j_row_major), npe::move(i_row_major));
 
 npe_end_code()
+
+

--- a/src/decimate.cpp
+++ b/src/decimate.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss 4 functions
 
 #include <common.h>

--- a/src/decimate.cpp
+++ b/src/decimate.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss 4 functions
 
 #include <common.h>
@@ -71,5 +78,3 @@ npe_begin_code()
   return std::make_tuple(reach, npe::move(u_row_major), npe::move(g_row_major), npe::move(j_row_major), npe::move(i_row_major));
 
 npe_end_code()
-
-

--- a/src/deform_skeleton.cpp
+++ b/src/deform_skeleton.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/deform_skeleton.cpp
+++ b/src/deform_skeleton.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/dihedral_angles.cpp
+++ b/src/dihedral_angles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -62,5 +69,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(theta), npe::move(cos_theta));
 
 npe_end_code()
-
-

--- a/src/dihedral_angles.cpp
+++ b/src/dihedral_angles.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -69,3 +62,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(theta), npe::move(cos_theta));
 
 npe_end_code()
+
+

--- a/src/dihedral_angles.cpp
+++ b/src/dihedral_angles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/direct_delta_mush.cpp
+++ b/src/direct_delta_mush.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Kishore Venkateshan
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/direct_delta_mush.cpp
+++ b/src/direct_delta_mush.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Kishore Venkateshan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/directed_edge_orientations.cpp
+++ b/src/directed_edge_orientations.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/directed_edge_orientations.cpp
+++ b/src/directed_edge_orientations.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/directed_edge_parents.cpp
+++ b/src/directed_edge_parents.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/directed_edge_parents.cpp
+++ b/src/directed_edge_parents.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -47,3 +40,5 @@ npe_begin_code()
   return npe::move(p);
 
 npe_end_code()
+
+

--- a/src/directed_edge_parents.cpp
+++ b/src/directed_edge_parents.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -40,5 +47,3 @@ npe_begin_code()
   return npe::move(p);
 
 npe_end_code()
-
-

--- a/src/doublearea.cpp
+++ b/src/doublearea.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -50,3 +43,4 @@ npe_begin_code()
   return npe::move(d_area);
 
 npe_end_code()
+

--- a/src/doublearea.cpp
+++ b/src/doublearea.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/doublearea.cpp
+++ b/src/doublearea.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -43,4 +50,3 @@ npe_begin_code()
   return npe::move(d_area);
 
 npe_end_code()
-

--- a/src/dqs.cpp
+++ b/src/dqs.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -77,3 +70,5 @@ npe_begin_code()
   return npe::move(u);
 
 npe_end_code()
+
+

--- a/src/dqs.cpp
+++ b/src/dqs.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -70,5 +77,3 @@ npe_begin_code()
   return npe::move(u);
 
 npe_end_code()
-
-

--- a/src/dqs.cpp
+++ b/src/dqs.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/ears.cpp
+++ b/src/ears.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -44,5 +51,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(ear), npe::move(ear_opp));
 
 npe_end_code()
-
-

--- a/src/ears.cpp
+++ b/src/ears.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,3 +44,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(ear), npe::move(ear_opp));
 
 npe_end_code()
+
+

--- a/src/ears.cpp
+++ b/src/ears.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edge_collapse_is_valid.cpp
+++ b/src/edge_collapse_is_valid.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -72,4 +79,3 @@ npe_begin_code()
   return ok;
 
 npe_end_code()
-

--- a/src/edge_collapse_is_valid.cpp
+++ b/src/edge_collapse_is_valid.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -79,3 +72,4 @@ npe_begin_code()
   return ok;
 
 npe_end_code()
+

--- a/src/edge_collapse_is_valid.cpp
+++ b/src/edge_collapse_is_valid.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edge_flaps.cpp
+++ b/src/edge_flaps.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -61,5 +68,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(e), npe::move(emap), npe::move(ef), npe::move(ei));
 
 npe_end_code()
-
-

--- a/src/edge_flaps.cpp
+++ b/src/edge_flaps.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -68,3 +61,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(e), npe::move(emap), npe::move(ef), npe::move(ei));
 
 npe_end_code()
+
+

--- a/src/edge_flaps.cpp
+++ b/src/edge_flaps.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edge_lengths.cpp
+++ b/src/edge_lengths.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -65,3 +58,5 @@ npe_begin_code()
   return npe::move(l);
 
 npe_end_code()
+
+

--- a/src/edge_lengths.cpp
+++ b/src/edge_lengths.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -58,5 +65,3 @@ npe_begin_code()
   return npe::move(l);
 
 npe_end_code()
-
-

--- a/src/edge_lengths.cpp
+++ b/src/edge_lengths.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edge_topology.cpp
+++ b/src/edge_topology.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edge_topology.cpp
+++ b/src/edge_topology.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edges.cpp
+++ b/src/edges.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edges.cpp
+++ b/src/edges.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/edges_to_path.cpp
+++ b/src/edges_to_path.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/edges_to_path.cpp
+++ b/src/edges_to_path.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -70,3 +63,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(i), npe::move(j), npe::move(k));
 
 npe_end_code()
+
+

--- a/src/edges_to_path.cpp
+++ b/src/edges_to_path.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -63,5 +70,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(i), npe::move(j), npe::move(k));
 
 npe_end_code()
-
-

--- a/src/euler_characteristic.cpp
+++ b/src/euler_characteristic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/euler_characteristic.cpp
+++ b/src/euler_characteristic.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -88,3 +81,5 @@ npe_begin_code()
   return igl::euler_characteristic(v, f);
 
 npe_end_code()
+
+

--- a/src/euler_characteristic.cpp
+++ b/src/euler_characteristic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -81,5 +88,3 @@ npe_begin_code()
   return igl::euler_characteristic(v, f);
 
 npe_end_code()
-
-

--- a/src/exact_geodesic.cpp
+++ b/src/exact_geodesic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -53,5 +60,3 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
-
-

--- a/src/exact_geodesic.cpp
+++ b/src/exact_geodesic.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -60,3 +53,5 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
+
+

--- a/src/exact_geodesic.cpp
+++ b/src/exact_geodesic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/exterior_edges.cpp
+++ b/src/exterior_edges.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // need assertion for a.rows = b.rows-1
 // __copy
 #include <npe.h>

--- a/src/exterior_edges.cpp
+++ b/src/exterior_edges.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // need assertion for a.rows = b.rows-1
 // __copy
 #include <npe.h>
@@ -54,4 +61,3 @@ npe_begin_code()
   return npe::move(e);
 
 npe_end_code()
-

--- a/src/exterior_edges.cpp
+++ b/src/exterior_edges.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // need assertion for a.rows = b.rows-1
 // __copy
 #include <npe.h>
@@ -61,3 +54,4 @@ npe_begin_code()
   return npe::move(e);
 
 npe_end_code()
+

--- a/src/extract_manifold_patches.cpp
+++ b/src/extract_manifold_patches.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/extract_manifold_patches.cpp
+++ b/src/extract_manifold_patches.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/extract_non_manifold_edge_curves.cpp
+++ b/src/extract_non_manifold_edge_curves.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -58,5 +65,3 @@ npe_begin_code()
   return curves;
 
 npe_end_code()
-
-

--- a/src/extract_non_manifold_edge_curves.cpp
+++ b/src/extract_non_manifold_edge_curves.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -65,3 +58,5 @@ npe_begin_code()
   return curves;
 
 npe_end_code()
+
+

--- a/src/extract_non_manifold_edge_curves.cpp
+++ b/src/extract_non_manifold_edge_curves.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/face_occurrences.cpp
+++ b/src/face_occurrences.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -44,5 +51,3 @@ npe_begin_code()
   return npe::move(c);
 
 npe_end_code()
-
-

--- a/src/face_occurrences.cpp
+++ b/src/face_occurrences.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,3 +44,5 @@ npe_begin_code()
   return npe::move(c);
 
 npe_end_code()
+
+

--- a/src/face_occurrences.cpp
+++ b/src/face_occurrences.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/faces_first.cpp
+++ b/src/faces_first.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/faces_first.cpp
+++ b/src/faces_first.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/facet_components.cpp
+++ b/src/facet_components.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Nico
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/facet_components.cpp
+++ b/src/facet_components.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Nico
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/false_barycentric_subdivision.cpp
+++ b/src/false_barycentric_subdivision.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -63,3 +56,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(vd), npe::move(fd));
 
 npe_end_code()
+
+

--- a/src/false_barycentric_subdivision.cpp
+++ b/src/false_barycentric_subdivision.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -56,5 +63,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(vd), npe::move(fd));
 
 npe_end_code()
-
-

--- a/src/false_barycentric_subdivision.cpp
+++ b/src/false_barycentric_subdivision.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/fast_winding_number.cpp
+++ b/src/fast_winding_number.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/fast_winding_number.cpp
+++ b/src/fast_winding_number.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/find_cross_field_singularities.cpp
+++ b/src/find_cross_field_singularities.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -119,3 +112,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(is_singularity), npe::move(singularity_index));
 
 npe_end_code()
+
+

--- a/src/find_cross_field_singularities.cpp
+++ b/src/find_cross_field_singularities.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/find_cross_field_singularities.cpp
+++ b/src/find_cross_field_singularities.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -112,5 +119,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(is_singularity), npe::move(singularity_index));
 
 npe_end_code()
-
-

--- a/src/fit_cubic_bezier.cpp
+++ b/src/fit_cubic_bezier.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/fit_cubic_bezier.cpp
+++ b/src/fit_cubic_bezier.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -54,3 +47,4 @@ npe_begin_code()
   return pybind11::detail::type_caster<decltype(c)>::cast(c, pybind11::return_value_policy::move, pybind11::none());
 
 npe_end_code()
+

--- a/src/fit_cubic_bezier.cpp
+++ b/src/fit_cubic_bezier.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -47,4 +54,3 @@ npe_begin_code()
   return pybind11::detail::type_caster<decltype(c)>::cast(c, pybind11::return_value_policy::move, pybind11::none());
 
 npe_end_code()
-

--- a/src/fit_plane.cpp
+++ b/src/fit_plane.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/fit_plane.cpp
+++ b/src/fit_plane.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -57,5 +64,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(n_row_major), npe::move(c_row_major));
 
 npe_end_code()
-
-

--- a/src/fit_plane.cpp
+++ b/src/fit_plane.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -64,3 +57,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(n_row_major), npe::move(c_row_major));
 
 npe_end_code()
+
+

--- a/src/flip_avoiding_line_search.cpp
+++ b/src/flip_avoiding_line_search.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/flip_avoiding_line_search.cpp
+++ b/src/flip_avoiding_line_search.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/flip_edge.cpp
+++ b/src/flip_edge.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Soboleva Natalia
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/flip_edge.cpp
+++ b/src/flip_edge.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Soboleva Natalia
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/flipped_triangles.cpp
+++ b/src/flipped_triangles.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/flipped_triangles.cpp
+++ b/src/flipped_triangles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/forward_kinematics.cpp
+++ b/src/forward_kinematics.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/forward_kinematics.cpp
+++ b/src/forward_kinematics.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/gaussian_curvature.cpp
+++ b/src/gaussian_curvature.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/gaussian_curvature.cpp
+++ b/src/gaussian_curvature.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -42,5 +49,3 @@ npe_begin_code()
   return npe::move(k);
 
 npe_end_code()
-
-

--- a/src/gaussian_curvature.cpp
+++ b/src/gaussian_curvature.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -49,3 +42,5 @@ npe_begin_code()
   return npe::move(k);
 
 npe_end_code()
+
+

--- a/src/grad.cpp
+++ b/src/grad.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -49,5 +56,3 @@ npe_begin_code()
   return npe::move(g);
 
 npe_end_code()
-
-

--- a/src/grad.cpp
+++ b/src/grad.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/grad.cpp
+++ b/src/grad.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -56,3 +49,5 @@ npe_begin_code()
   return npe::move(g);
 
 npe_end_code()
+
+

--- a/src/grad_intrinsic.cpp
+++ b/src/grad_intrinsic.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -64,3 +57,5 @@ npe_begin_code()
   return npe::move(g);
 
 npe_end_code()
+
+

--- a/src/grad_intrinsic.cpp
+++ b/src/grad_intrinsic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -57,5 +64,3 @@ npe_begin_code()
   return npe::move(g);
 
 npe_end_code()
-
-

--- a/src/grad_intrinsic.cpp
+++ b/src/grad_intrinsic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/harmonic.cpp
+++ b/src/harmonic.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -254,3 +247,5 @@ npe_begin_code()
   return npe::move(q);
 
 npe_end_code()
+
+

--- a/src/harmonic.cpp
+++ b/src/harmonic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -247,5 +254,3 @@ npe_begin_code()
   return npe::move(q);
 
 npe_end_code()
-
-

--- a/src/harmonic.cpp
+++ b/src/harmonic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/hausdorff.cpp
+++ b/src/hausdorff.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -74,3 +67,6 @@ npe_begin_code()
   return d;
 
 npe_end_code()
+
+
+

--- a/src/hausdorff.cpp
+++ b/src/hausdorff.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -67,6 +74,3 @@ npe_begin_code()
   return d;
 
 npe_end_code()
-
-
-

--- a/src/hausdorff.cpp
+++ b/src/hausdorff.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/heat_geodesic.cpp
+++ b/src/heat_geodesic.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -59,3 +52,5 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
+
+

--- a/src/heat_geodesic.cpp
+++ b/src/heat_geodesic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -52,5 +59,3 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
-
-

--- a/src/heat_geodesic.cpp
+++ b/src/heat_geodesic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/hessian.cpp
+++ b/src/hessian.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <common.h>
@@ -52,3 +45,5 @@ npe_begin_code()
   igl::hessian(v, f, h);
   return npe::move(h);
 npe_end_code()
+
+

--- a/src/hessian.cpp
+++ b/src/hessian.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <common.h>
@@ -45,5 +52,3 @@ npe_begin_code()
   igl::hessian(v, f, h);
   return npe::move(h);
 npe_end_code()
-
-

--- a/src/hessian.cpp
+++ b/src/hessian.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <common.h>

--- a/src/hessian_energy.cpp
+++ b/src/hessian_energy.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // might be sparse matrix problem
 
 #include <common.h>
@@ -60,3 +53,5 @@ npe_begin_code()
   return npe::move(q);
 
 npe_end_code()
+
+

--- a/src/hessian_energy.cpp
+++ b/src/hessian_energy.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // might be sparse matrix problem
 
 #include <common.h>

--- a/src/hessian_energy.cpp
+++ b/src/hessian_energy.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // might be sparse matrix problem
 
 #include <common.h>
@@ -53,5 +60,3 @@ npe_begin_code()
   return npe::move(q);
 
 npe_end_code()
-
-

--- a/src/in_element.cpp
+++ b/src/in_element.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/in_element.cpp
+++ b/src/in_element.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -56,3 +49,6 @@ npe_begin_code()
   return npe::move(I);
 
 npe_end_code()
+
+
+

--- a/src/in_element.cpp
+++ b/src/in_element.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -49,6 +56,3 @@ npe_begin_code()
   return npe::move(I);
 
 npe_end_code()
-
-
-

--- a/src/inradius.cpp
+++ b/src/inradius.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -42,5 +49,3 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
-
-

--- a/src/inradius.cpp
+++ b/src/inradius.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -49,3 +42,5 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
+
+

--- a/src/inradius.cpp
+++ b/src/inradius.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/internal_angles.cpp
+++ b/src/internal_angles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/internal_angles.cpp
+++ b/src/internal_angles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -134,5 +141,3 @@ npe_end_code()
 //  return npe::move(k);
 
 //npe_end_code()
-
-

--- a/src/internal_angles.cpp
+++ b/src/internal_angles.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -141,3 +134,5 @@ npe_end_code()
 //  return npe::move(k);
 
 //npe_end_code()
+
+

--- a/src/intrinsic_delaunay_cotmatrix.cpp
+++ b/src/intrinsic_delaunay_cotmatrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -58,3 +51,4 @@ npe_begin_code()
   return std::make_tuple(npe::move(l), npe::move(l_intrinsic), npe::move(f_intrinsic));
 
 npe_end_code()
+

--- a/src/intrinsic_delaunay_cotmatrix.cpp
+++ b/src/intrinsic_delaunay_cotmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/intrinsic_delaunay_cotmatrix.cpp
+++ b/src/intrinsic_delaunay_cotmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,4 +58,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(l), npe::move(l_intrinsic), npe::move(f_intrinsic));
 
 npe_end_code()
-

--- a/src/intrinsic_delaunay_triangulation.cpp
+++ b/src/intrinsic_delaunay_triangulation.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/intrinsic_delaunay_triangulation.cpp
+++ b/src/intrinsic_delaunay_triangulation.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/is_border_vertex.cpp
+++ b/src/is_border_vertex.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,3 +44,5 @@ npe_begin_code()
   return res;
 
 npe_end_code()
+
+

--- a/src/is_border_vertex.cpp
+++ b/src/is_border_vertex.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -44,5 +51,3 @@ npe_begin_code()
   return res;
 
 npe_end_code()
-
-

--- a/src/is_border_vertex.cpp
+++ b/src/is_border_vertex.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/is_delaunay.cpp
+++ b/src/is_delaunay.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -56,3 +49,4 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
+

--- a/src/is_delaunay.cpp
+++ b/src/is_delaunay.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -49,4 +56,3 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
-

--- a/src/is_delaunay.cpp
+++ b/src/is_delaunay.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/is_edge_manifold.cpp
+++ b/src/is_edge_manifold.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example, decide if to remove the first function
 
 #include <common.h>

--- a/src/is_edge_manifold.cpp
+++ b/src/is_edge_manifold.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example, decide if to remove the first function
 
 #include <common.h>
@@ -30,3 +23,5 @@ npe_begin_code()
   return igl::is_edge_manifold(f);
 
 npe_end_code()
+
+

--- a/src/is_edge_manifold.cpp
+++ b/src/is_edge_manifold.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example, decide if to remove the first function
 
 #include <common.h>
@@ -23,5 +30,3 @@ npe_begin_code()
   return igl::is_edge_manifold(f);
 
 npe_end_code()
-
-

--- a/src/is_intrinsic_delaunay.cpp
+++ b/src/is_intrinsic_delaunay.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -57,3 +50,4 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
+

--- a/src/is_intrinsic_delaunay.cpp
+++ b/src/is_intrinsic_delaunay.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -50,4 +57,3 @@ npe_begin_code()
   return npe::move(d);
 
 npe_end_code()
-

--- a/src/is_intrinsic_delaunay.cpp
+++ b/src/is_intrinsic_delaunay.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/is_irregular_vertex.cpp
+++ b/src/is_irregular_vertex.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -41,5 +48,3 @@ npe_begin_code()
   return res;
 
 npe_end_code()
-
-

--- a/src/is_irregular_vertex.cpp
+++ b/src/is_irregular_vertex.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -48,3 +41,5 @@ npe_begin_code()
   return res;
 
 npe_end_code()
+
+

--- a/src/is_irregular_vertex.cpp
+++ b/src/is_irregular_vertex.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/isolines.cpp
+++ b/src/isolines.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>

--- a/src/isolines.cpp
+++ b/src/isolines.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>
@@ -61,3 +54,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(iso_v), npe::move(iso_e));
 
 npe_end_code()
+
+

--- a/src/isolines.cpp
+++ b/src/isolines.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>
@@ -54,5 +61,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(iso_v), npe::move(iso_e));
 
 npe_end_code()
-
-

--- a/src/iterative_closest_point.cpp
+++ b/src/iterative_closest_point.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -130,5 +137,3 @@ npe_end_code()
 //   return std::make_tuple(npe::move(r), npe::move(t));
 
 // npe_end_code()
-
-

--- a/src/iterative_closest_point.cpp
+++ b/src/iterative_closest_point.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -137,3 +130,5 @@ npe_end_code()
 //   return std::make_tuple(npe::move(r), npe::move(t));
 
 // npe_end_code()
+
+

--- a/src/iterative_closest_point.cpp
+++ b/src/iterative_closest_point.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/lbs_matrix.cpp
+++ b/src/lbs_matrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -209,5 +216,3 @@ npe_end_code()
 //   return npe::move(m);
 
 // npe_end_code()
-
-

--- a/src/lbs_matrix.cpp
+++ b/src/lbs_matrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -216,3 +209,5 @@ npe_end_code()
 //   return npe::move(m);
 
 // npe_end_code()
+
+

--- a/src/lbs_matrix.cpp
+++ b/src/lbs_matrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/line_segment_in_rectangle.cpp
+++ b/src/line_segment_in_rectangle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/line_segment_in_rectangle.cpp
+++ b/src/line_segment_in_rectangle.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/local_basis.cpp
+++ b/src/local_basis.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -53,3 +46,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(b1), npe::move(b2), npe::move(b3));
 
 npe_end_code()
+
+

--- a/src/local_basis.cpp
+++ b/src/local_basis.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -46,5 +53,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(b1), npe::move(b2), npe::move(b3));
 
 npe_end_code()
-
-

--- a/src/local_basis.cpp
+++ b/src/local_basis.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/look_at.cpp
+++ b/src/look_at.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -53,5 +60,3 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
-
-

--- a/src/look_at.cpp
+++ b/src/look_at.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -60,3 +53,5 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
+
+

--- a/src/look_at.cpp
+++ b/src/look_at.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/lscm.cpp
+++ b/src/lscm.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/lscm.cpp
+++ b/src/lscm.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>
@@ -63,5 +70,3 @@ npe_begin_code()
   return std::make_tuple(success, npe::move(uv_row_major));
 
 npe_end_code()
-
-

--- a/src/lscm.cpp
+++ b/src/lscm.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>
@@ -70,3 +63,5 @@ npe_begin_code()
   return std::make_tuple(success, npe::move(uv_row_major));
 
 npe_end_code()
+
+

--- a/src/map_vertices_to_circle.cpp
+++ b/src/map_vertices_to_circle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/map_vertices_to_circle.cpp
+++ b/src/map_vertices_to_circle.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>
@@ -54,3 +47,5 @@ npe_begin_code()
   return npe::move(uv_row_major);
 
 npe_end_code()
+
+

--- a/src/map_vertices_to_circle.cpp
+++ b/src/map_vertices_to_circle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>
@@ -47,5 +54,3 @@ npe_begin_code()
   return npe::move(uv_row_major);
 
 npe_end_code()
-
-

--- a/src/marching_cubes.cpp
+++ b/src/marching_cubes.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Thomas
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/marching_cubes.cpp
+++ b/src/marching_cubes.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Thomas
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/marching_tets.cpp
+++ b/src/marching_tets.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/marching_tets.cpp
+++ b/src/marching_tets.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/massmatrix.cpp
+++ b/src/massmatrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -64,3 +57,5 @@ npe_begin_code()
   return npe::move(m);
 
 npe_end_code()
+
+

--- a/src/massmatrix.cpp
+++ b/src/massmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/massmatrix.cpp
+++ b/src/massmatrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -57,5 +64,3 @@ npe_begin_code()
   return npe::move(m);
 
 npe_end_code()
-
-

--- a/src/massmatrix_intrinsic.cpp
+++ b/src/massmatrix_intrinsic.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/massmatrix_intrinsic.cpp
+++ b/src/massmatrix_intrinsic.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/min_quad_with_fixed.cpp
+++ b/src/min_quad_with_fixed.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example remove __copy
 
 #include <common.h>

--- a/src/min_quad_with_fixed.cpp
+++ b/src/min_quad_with_fixed.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example remove __copy
 
 #include <common.h>

--- a/src/moments.cpp
+++ b/src/moments.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/moments.cpp
+++ b/src/moments.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -32,4 +39,3 @@ npe_begin_code()
   igl::moments(V, F, m0, m1, m2);
   return std::make_tuple(m0,npe::move(m1),npe::move(m2));
 npe_end_code()
-

--- a/src/moments.cpp
+++ b/src/moments.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -39,3 +32,4 @@ npe_begin_code()
   igl::moments(V, F, m0, m1, m2);
   return std::make_tuple(m0,npe::move(m1),npe::move(m2));
 npe_end_code()
+

--- a/src/mvc.cpp
+++ b/src/mvc.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -62,3 +55,5 @@ npe_begin_code()
   EigenDenseLike<npe_Matrix_v> w = w_copy.template cast<npe_Scalar_v>();
   return npe::move(w);
 npe_end_code()
+
+

--- a/src/mvc.cpp
+++ b/src/mvc.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/mvc.cpp
+++ b/src/mvc.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -55,5 +62,3 @@ npe_begin_code()
   EigenDenseLike<npe_Matrix_v> w = w_copy.template cast<npe_Scalar_v>();
   return npe::move(w);
 npe_end_code()
-
-

--- a/src/normal_derivative.cpp
+++ b/src/normal_derivative.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -50,5 +57,3 @@ npe_begin_code()
   return npe::move(dd);
 
 npe_end_code()
-
-

--- a/src/normal_derivative.cpp
+++ b/src/normal_derivative.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -57,3 +50,5 @@ npe_begin_code()
   return npe::move(dd);
 
 npe_end_code()
+
+

--- a/src/normal_derivative.cpp
+++ b/src/normal_derivative.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/offset_surface.cpp
+++ b/src/offset_surface.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 // TODO: remove __copy
 // copy is necessary since the winding number only supports matrices

--- a/src/offset_surface.cpp
+++ b/src/offset_surface.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 // TODO: remove __copy
 // copy is necessary since the winding number only supports matrices

--- a/src/orient_outward.cpp
+++ b/src/orient_outward.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -64,3 +57,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(ff), npe::move(i));
 
 npe_end_code()
+
+

--- a/src/orient_outward.cpp
+++ b/src/orient_outward.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/orient_outward.cpp
+++ b/src/orient_outward.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -57,5 +64,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(ff), npe::move(i));
 
 npe_end_code()
-
-

--- a/src/orientable_patches.cpp
+++ b/src/orientable_patches.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/orientable_patches.cpp
+++ b/src/orientable_patches.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -40,4 +47,3 @@ npe_begin_code()
     return std::make_tuple(npe::move(c), npe::move(A));
 
 npe_end_code()
-

--- a/src/orientable_patches.cpp
+++ b/src/orientable_patches.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -47,3 +40,4 @@ npe_begin_code()
     return std::make_tuple(npe::move(c), npe::move(A));
 
 npe_end_code()
+

--- a/src/oriented_facets.cpp
+++ b/src/oriented_facets.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -44,5 +51,3 @@ npe_begin_code()
   return npe::move(e);
 
 npe_end_code()
-
-

--- a/src/oriented_facets.cpp
+++ b/src/oriented_facets.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/oriented_facets.cpp
+++ b/src/oriented_facets.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,3 +44,5 @@ npe_begin_code()
   return npe::move(e);
 
 npe_end_code()
+
+

--- a/src/outer_element.cpp
+++ b/src/outer_element.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -169,5 +176,3 @@ npe_begin_code()
   return std::make_tuple(face, flipped);
 
 npe_end_code()
-
-

--- a/src/outer_element.cpp
+++ b/src/outer_element.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -176,3 +169,5 @@ npe_begin_code()
   return std::make_tuple(face, flipped);
 
 npe_end_code()
+
+

--- a/src/outer_element.cpp
+++ b/src/outer_element.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -70,3 +63,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(g), npe::move(s), npe::move(d));
 
 npe_end_code()
+
+

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -63,5 +70,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(g), npe::move(s), npe::move(d));
 
 npe_end_code()
-
-

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/path_to_edges.cpp
+++ b/src/path_to_edges.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/path_to_edges.cpp
+++ b/src/path_to_edges.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/per_corner_normals.cpp
+++ b/src/per_corner_normals.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -52,3 +45,4 @@ npe_begin_code()
   return npe::move(n);
 
 npe_end_code()
+

--- a/src/per_corner_normals.cpp
+++ b/src/per_corner_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -45,4 +52,3 @@ npe_begin_code()
   return npe::move(n);
 
 npe_end_code()
-

--- a/src/per_corner_normals.cpp
+++ b/src/per_corner_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/per_edge_normals.cpp
+++ b/src/per_edge_normals.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __miss __example
 
 #include <common.h>
@@ -64,3 +57,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(n), npe::move(e), npe::move(emap));
 
 npe_end_code()
+
+

--- a/src/per_edge_normals.cpp
+++ b/src/per_edge_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __miss __example
 
 #include <common.h>
@@ -57,5 +64,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(n), npe::move(e), npe::move(emap));
 
 npe_end_code()
-
-

--- a/src/per_edge_normals.cpp
+++ b/src/per_edge_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __miss __example
 
 #include <common.h>

--- a/src/per_face_normals.cpp
+++ b/src/per_face_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss
 
 #include <common.h>

--- a/src/per_face_normals.cpp
+++ b/src/per_face_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss
 
 #include <common.h>
@@ -50,4 +57,3 @@ npe_begin_code()
   return npe::move(n);
 
 npe_end_code()
-

--- a/src/per_face_normals.cpp
+++ b/src/per_face_normals.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss
 
 #include <common.h>
@@ -57,3 +50,4 @@ npe_begin_code()
   return npe::move(n);
 
 npe_end_code()
+

--- a/src/per_vertex_attribute_smoothing.cpp
+++ b/src/per_vertex_attribute_smoothing.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/per_vertex_attribute_smoothing.cpp
+++ b/src/per_vertex_attribute_smoothing.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -56,3 +49,5 @@ npe_begin_code()
   return npe::move(aout_row_major);
 
 npe_end_code()
+
+

--- a/src/per_vertex_attribute_smoothing.cpp
+++ b/src/per_vertex_attribute_smoothing.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -49,5 +56,3 @@ npe_begin_code()
   return npe::move(aout_row_major);
 
 npe_end_code()
-
-

--- a/src/per_vertex_normals.cpp
+++ b/src/per_vertex_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,5 +58,3 @@ npe_begin_code()
   return npe::move(n);
 
 npe_end_code()
-
-

--- a/src/per_vertex_normals.cpp
+++ b/src/per_vertex_normals.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/per_vertex_normals.cpp
+++ b/src/per_vertex_normals.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -58,3 +51,5 @@ npe_begin_code()
   return npe::move(n);
 
 npe_end_code()
+
+

--- a/src/piecewise_constant_winding_number.cpp
+++ b/src/piecewise_constant_winding_number.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>
@@ -63,5 +70,3 @@ npe_begin_code()
   return igl::piecewise_constant_winding_number(f);
 
 npe_end_code()
-
-

--- a/src/piecewise_constant_winding_number.cpp
+++ b/src/piecewise_constant_winding_number.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>

--- a/src/piecewise_constant_winding_number.cpp
+++ b/src/piecewise_constant_winding_number.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>
@@ -70,3 +63,5 @@ npe_begin_code()
   return igl::piecewise_constant_winding_number(f);
 
 npe_end_code()
+
+

--- a/src/planarize_quad_mesh.cpp
+++ b/src/planarize_quad_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -49,5 +56,3 @@ npe_begin_code()
   return npe::move(out);
 
 npe_end_code()
-
-

--- a/src/planarize_quad_mesh.cpp
+++ b/src/planarize_quad_mesh.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -56,3 +49,5 @@ npe_begin_code()
   return npe::move(out);
 
 npe_end_code()
+
+

--- a/src/planarize_quad_mesh.cpp
+++ b/src/planarize_quad_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/point_in_circle.cpp
+++ b/src/point_in_circle.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/point_in_circle.h>
@@ -53,3 +46,5 @@ npe_begin_code()
   return in;
 
 npe_end_code()
+
+

--- a/src/point_in_circle.cpp
+++ b/src/point_in_circle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/point_in_circle.h>
@@ -46,5 +53,3 @@ npe_begin_code()
   return in;
 
 npe_end_code()
-
-

--- a/src/point_in_circle.cpp
+++ b/src/point_in_circle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/point_in_circle.h>

--- a/src/point_mesh_squared_distance.cpp
+++ b/src/point_mesh_squared_distance.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -85,3 +78,5 @@ npe_begin_code()
 return std::make_tuple(npe::move(sqr_d_row_maj), npe::move(i_row_maj), npe::move(c_row_maj));
 
 npe_end_code()
+
+

--- a/src/point_mesh_squared_distance.cpp
+++ b/src/point_mesh_squared_distance.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/point_mesh_squared_distance.cpp
+++ b/src/point_mesh_squared_distance.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -78,5 +85,3 @@ npe_begin_code()
 return std::make_tuple(npe::move(sqr_d_row_maj), npe::move(i_row_maj), npe::move(c_row_maj));
 
 npe_end_code()
-
-

--- a/src/point_simplex_squared_distance.cpp
+++ b/src/point_simplex_squared_distance.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -66,3 +59,5 @@ npe_begin_code()
   return std::make_tuple(sqr_d, npe::move(c), npe::move(b));
 
 npe_end_code()
+
+

--- a/src/point_simplex_squared_distance.cpp
+++ b/src/point_simplex_squared_distance.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -59,5 +66,3 @@ npe_begin_code()
   return std::make_tuple(sqr_d, npe::move(c), npe::move(b));
 
 npe_end_code()
-
-

--- a/src/point_simplex_squared_distance.cpp
+++ b/src/point_simplex_squared_distance.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/polar_dec.cpp
+++ b/src/polar_dec.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -48,5 +55,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(r), npe::move(t));
 
 npe_end_code()
-
-

--- a/src/polar_dec.cpp
+++ b/src/polar_dec.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -55,3 +48,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(r), npe::move(t));
 
 npe_end_code()
+
+

--- a/src/polar_dec.cpp
+++ b/src/polar_dec.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/principal_curvature.cpp
+++ b/src/principal_curvature.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <tuple>
 #include <common.h>
 #include <npe.h>
@@ -59,3 +52,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(pd1), npe::move(pd2), npe::move(pv1), npe::move(pv2));
 
 npe_end_code()
+
+

--- a/src/principal_curvature.cpp
+++ b/src/principal_curvature.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <tuple>
 #include <common.h>
 #include <npe.h>
@@ -52,5 +59,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(pd1), npe::move(pd2), npe::move(pv1), npe::move(pv2));
 
 npe_end_code()
-
-

--- a/src/principal_curvature.cpp
+++ b/src/principal_curvature.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <tuple>
 #include <common.h>
 #include <npe.h>

--- a/src/procrustes.cpp
+++ b/src/procrustes.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss
 
 #include <common.h>
@@ -74,3 +67,4 @@ npe_begin_code()
   return std::make_tuple(scale, npe::move(r), npe::move(t));
 
 npe_end_code()
+

--- a/src/procrustes.cpp
+++ b/src/procrustes.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss
 
 #include <common.h>
@@ -67,4 +74,3 @@ npe_begin_code()
   return std::make_tuple(scale, npe::move(r), npe::move(t));
 
 npe_end_code()
-

--- a/src/procrustes.cpp
+++ b/src/procrustes.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss
 
 #include <common.h>

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/project_isometrically_to_plane.cpp
+++ b/src/project_isometrically_to_plane.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -48,5 +55,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(u), npe::move(uf), npe::move(i));
 
 npe_end_code()
-
-

--- a/src/project_isometrically_to_plane.cpp
+++ b/src/project_isometrically_to_plane.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/project_isometrically_to_plane.cpp
+++ b/src/project_isometrically_to_plane.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -55,3 +48,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(u), npe::move(uf), npe::move(i));
 
 npe_end_code()
+
+

--- a/src/project_to_line.cpp
+++ b/src/project_to_line.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/project_to_line.cpp
+++ b/src/project_to_line.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -75,4 +82,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(t), npe::move(sqr_d));
 
 npe_end_code()
-

--- a/src/project_to_line.cpp
+++ b/src/project_to_line.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -82,3 +75,4 @@ npe_begin_code()
   return std::make_tuple(npe::move(t), npe::move(sqr_d));
 
 npe_end_code()
+

--- a/src/project_to_line_segment.cpp
+++ b/src/project_to_line_segment.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -81,3 +74,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(t), npe::move(sqr_d));
 
 npe_end_code()
+
+

--- a/src/project_to_line_segment.cpp
+++ b/src/project_to_line_segment.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -74,5 +81,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(t), npe::move(sqr_d));
 
 npe_end_code()
-
-

--- a/src/project_to_line_segment.cpp
+++ b/src/project_to_line_segment.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/pso.cpp
+++ b/src/pso.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <pybind11/functional.h>

--- a/src/pso.cpp
+++ b/src/pso.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <pybind11/functional.h>

--- a/src/qslim.cpp
+++ b/src/qslim.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/qslim.cpp
+++ b/src/qslim.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -81,3 +74,5 @@ npe_begin_code()
   return std::make_tuple(success, npe::move(u_row_major), npe::move(g_row_major), npe::move(j_row_major), npe::move(i_row_major));
 
 npe_end_code()
+
+

--- a/src/qslim.cpp
+++ b/src/qslim.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -74,5 +81,3 @@ npe_begin_code()
   return std::make_tuple(success, npe::move(u_row_major), npe::move(g_row_major), npe::move(j_row_major), npe::move(i_row_major));
 
 npe_end_code()
-
-

--- a/src/quad_grid.cpp
+++ b/src/quad_grid.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/quad_grid.cpp
+++ b/src/quad_grid.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/quad_planarity.cpp
+++ b/src/quad_planarity.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: missing __example
 
 #include <common.h>

--- a/src/quad_planarity.cpp
+++ b/src/quad_planarity.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: missing __example
 
 #include <common.h>
@@ -49,3 +42,5 @@ npe_begin_code()
   return npe::move(p);
 
 npe_end_code()
+
+

--- a/src/quad_planarity.cpp
+++ b/src/quad_planarity.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: missing __example
 
 #include <common.h>
@@ -42,5 +49,3 @@ npe_begin_code()
   return npe::move(p);
 
 npe_end_code()
-
-

--- a/src/ramer_douglas_peucker.cpp
+++ b/src/ramer_douglas_peucker.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -58,3 +51,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(s), npe::move(j), npe::move(q));
 
 npe_end_code()
+
+

--- a/src/ramer_douglas_peucker.cpp
+++ b/src/ramer_douglas_peucker.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -51,5 +58,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(s), npe::move(j), npe::move(q));
 
 npe_end_code()
-
-

--- a/src/ramer_douglas_peucker.cpp
+++ b/src/ramer_douglas_peucker.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/random_points_on_mesh.cpp
+++ b/src/random_points_on_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/random_points_on_mesh.cpp
+++ b/src/random_points_on_mesh.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/random_search.cpp
+++ b/src/random_search.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <pybind11/functional.h>

--- a/src/random_search.cpp
+++ b/src/random_search.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <pybind11/functional.h>

--- a/src/ray_box_intersect.cpp
+++ b/src/ray_box_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/ray_box_intersect.cpp
+++ b/src/ray_box_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -69,5 +76,3 @@ npe_begin_code()
   return std::make_tuple(hit, tmin, tmax);
 
 npe_end_code()
-
-

--- a/src/ray_box_intersect.cpp
+++ b/src/ray_box_intersect.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -76,3 +69,5 @@ npe_begin_code()
   return std::make_tuple(hit, tmin, tmax);
 
 npe_end_code()
+
+

--- a/src/ray_mesh_intersect.cpp
+++ b/src/ray_mesh_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -99,4 +106,3 @@ npe_end_code()
 //   return npe::move(hit);
 
 // npe_end_code()
-

--- a/src/ray_mesh_intersect.cpp
+++ b/src/ray_mesh_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/ray_mesh_intersect.cpp
+++ b/src/ray_mesh_intersect.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -106,3 +99,4 @@ npe_end_code()
 //   return npe::move(hit);
 
 // npe_end_code()
+

--- a/src/ray_sphere_intersect.cpp
+++ b/src/ray_sphere_intersect.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -69,3 +62,5 @@ npe_begin_code()
   return std::make_tuple(inters, t0, t1);
 
 npe_end_code()
+
+

--- a/src/ray_sphere_intersect.cpp
+++ b/src/ray_sphere_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/ray_sphere_intersect.cpp
+++ b/src/ray_sphere_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -62,5 +69,3 @@ npe_begin_code()
   return std::make_tuple(inters, t0, t1);
 
 npe_end_code()
-
-

--- a/src/readDMAT.cpp
+++ b/src/readDMAT.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 

--- a/src/readDMAT.cpp
+++ b/src/readDMAT.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 
@@ -68,3 +61,6 @@ npe_begin_code()
   }
 
 npe_end_code()
+
+
+

--- a/src/readDMAT.cpp
+++ b/src/readDMAT.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 
@@ -61,6 +68,3 @@ npe_begin_code()
   }
 
 npe_end_code()
-
-
-

--- a/src/readMESH.cpp
+++ b/src/readMESH.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/readMESH.cpp
+++ b/src/readMESH.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/readMSH.cpp
+++ b/src/readMSH.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/readMSH.h>
@@ -59,5 +66,3 @@ npe_begin_code()
   throw pybind11::type_error("Only float32 and float64 dtypes are supported.");
 
 npe_end_code()
-
-

--- a/src/readMSH.cpp
+++ b/src/readMSH.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/readMSH.h>

--- a/src/readMSH.cpp
+++ b/src/readMSH.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/readMSH.h>
@@ -66,3 +59,5 @@ npe_begin_code()
   throw pybind11::type_error("Only float32 and float64 dtypes are supported.");
 
 npe_end_code()
+
+

--- a/src/readOBJ.cpp
+++ b/src/readOBJ.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/readOBJ.cpp
+++ b/src/readOBJ.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/readOFF.cpp
+++ b/src/readOFF.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/readOFF.cpp
+++ b/src/readOFF.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/readTGF.cpp
+++ b/src/readTGF.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 

--- a/src/readTGF.cpp
+++ b/src/readTGF.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 

--- a/src/read_triangle_mesh.cpp
+++ b/src/read_triangle_mesh.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/read_triangle_mesh.cpp
+++ b/src/read_triangle_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/remove_duplicate_vertices.cpp
+++ b/src/remove_duplicate_vertices.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/remove_duplicate_vertices.cpp
+++ b/src/remove_duplicate_vertices.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -71,3 +64,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(sv_row_major), npe::move(svi), npe::move(svj), npe::move(sf));
 
 npe_end_code()
+
+

--- a/src/remove_duplicate_vertices.cpp
+++ b/src/remove_duplicate_vertices.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -64,5 +71,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(sv_row_major), npe::move(svi), npe::move(svj), npe::move(sf));
 
 npe_end_code()
-
-

--- a/src/remove_duplicates.cpp
+++ b/src/remove_duplicates.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/remove_duplicates.cpp
+++ b/src/remove_duplicates.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -67,3 +60,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(sv_row_major), npe::move(sf));
 
 npe_end_code()
+
+

--- a/src/remove_duplicates.cpp
+++ b/src/remove_duplicates.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -60,5 +67,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(sv_row_major), npe::move(sf));
 
 npe_end_code()
-
-

--- a/src/remove_unreferenced.cpp
+++ b/src/remove_unreferenced.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/remove_unreferenced.cpp
+++ b/src/remove_unreferenced.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -54,4 +61,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(nv), npe::move(nf), npe::move(i), npe::move(j));
 
 npe_end_code()
-

--- a/src/remove_unreferenced.cpp
+++ b/src/remove_unreferenced.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -61,3 +54,4 @@ npe_begin_code()
   return std::make_tuple(npe::move(nv), npe::move(nf), npe::move(i), npe::move(j));
 
 npe_end_code()
+

--- a/src/resolve_duplicated_faces.cpp
+++ b/src/resolve_duplicated_faces.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/resolve_duplicated_faces.cpp
+++ b/src/resolve_duplicated_faces.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -65,3 +58,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(f2), npe::move(j));
 
 npe_end_code()
+
+

--- a/src/resolve_duplicated_faces.cpp
+++ b/src/resolve_duplicated_faces.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -58,5 +65,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(f2), npe::move(j));
 
 npe_end_code()
-
-

--- a/src/rigid_alignment.cpp
+++ b/src/rigid_alignment.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -70,3 +63,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(r), npe::move(t));
 
 npe_end_code()
+
+

--- a/src/rigid_alignment.cpp
+++ b/src/rigid_alignment.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -63,5 +70,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(r), npe::move(t));
 
 npe_end_code()
-
-

--- a/src/rigid_alignment.cpp
+++ b/src/rigid_alignment.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/rotate_vectors.cpp
+++ b/src/rotate_vectors.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/rotate_vectors.cpp
+++ b/src/rotate_vectors.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/sample_edges.cpp
+++ b/src/sample_edges.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/sample_edges.cpp
+++ b/src/sample_edges.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -58,5 +65,3 @@ npe_begin_code()
   return npe::move(s);
 
 npe_end_code()
-
-

--- a/src/sample_edges.cpp
+++ b/src/sample_edges.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -65,3 +58,5 @@ npe_begin_code()
   return npe::move(s);
 
 npe_end_code()
+
+

--- a/src/segment_segment_intersect.cpp
+++ b/src/segment_segment_intersect.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 // error at line 33 and 41, saying cross is only for certain size matrices
 
@@ -81,3 +74,5 @@ npe_begin_code()
   return std::make_tuple(is_intersect, t, u, eps);
 
 npe_end_code()
+
+

--- a/src/segment_segment_intersect.cpp
+++ b/src/segment_segment_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 // error at line 33 and 41, saying cross is only for certain size matrices
 
@@ -74,5 +81,3 @@ npe_begin_code()
   return std::make_tuple(is_intersect, t, u, eps);
 
 npe_end_code()
-
-

--- a/src/segment_segment_intersect.cpp
+++ b/src/segment_segment_intersect.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 // error at line 33 and 41, saying cross is only for certain size matrices
 

--- a/src/shape_diameter_function.cpp
+++ b/src/shape_diameter_function.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example __miss
 
 
@@ -60,5 +67,3 @@ npe_begin_code()
   return npe::move(s);
 
 npe_end_code()
-
-

--- a/src/shape_diameter_function.cpp
+++ b/src/shape_diameter_function.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example __miss
 
 
@@ -67,3 +60,5 @@ npe_begin_code()
   return npe::move(s);
 
 npe_end_code()
+
+

--- a/src/shape_diameter_function.cpp
+++ b/src/shape_diameter_function.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example __miss
 
 

--- a/src/sharp_edges.cpp
+++ b/src/sharp_edges.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/sharp_edges.cpp
+++ b/src/sharp_edges.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/signed_angle.cpp
+++ b/src/signed_angle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -83,5 +90,3 @@ npe_begin_code()
   return angle;
 
 npe_end_code()
-
-

--- a/src/signed_angle.cpp
+++ b/src/signed_angle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/signed_angle.cpp
+++ b/src/signed_angle.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -90,3 +83,5 @@ npe_begin_code()
   return angle;
 
 npe_end_code()
+
+

--- a/src/signed_distance.cpp
+++ b/src/signed_distance.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Francis Williams
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -59,11 +66,17 @@ npe_begin_code()
         //NOTE: compiler concats adjacent string literals. 
         throw pybind11::value_error(
             "Parameter sign_type invalid, must be one of:"
-            "\n\t0: Use fast pseudo-normal test [Bærentzen & Aanæs 2005]"
-            "\n\t1: Use winding number [Jacobson, Kavan Sorking-Hornug 2013]"
-            "\n\t2: Default (pseudo-normal)"
-            "\n\t3: Unsigned"
-            "\n\t4: Use Fast winding number [Barill, Dickson, Schmidt, Levin, Jacobson 2018]\n"
+            "
+	0: Use fast pseudo-normal test [Bærentzen & Aanæs 2005]"
+            "
+	1: Use winding number [Jacobson, Kavan Sorking-Hornug 2013]"
+            "
+	2: Default (pseudo-normal)"
+            "
+	3: Unsigned"
+            "
+	4: Use Fast winding number [Barill, Dickson, Schmidt, Levin, Jacobson 2018]
+"
         );
     }
 
@@ -96,6 +109,3 @@ npe_begin_code()
     }
 
 npe_end_code()
-
-
-

--- a/src/signed_distance.cpp
+++ b/src/signed_distance.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Francis Williams
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -66,17 +59,11 @@ npe_begin_code()
         //NOTE: compiler concats adjacent string literals. 
         throw pybind11::value_error(
             "Parameter sign_type invalid, must be one of:"
-            "
-	0: Use fast pseudo-normal test [Bærentzen & Aanæs 2005]"
-            "
-	1: Use winding number [Jacobson, Kavan Sorking-Hornug 2013]"
-            "
-	2: Default (pseudo-normal)"
-            "
-	3: Unsigned"
-            "
-	4: Use Fast winding number [Barill, Dickson, Schmidt, Levin, Jacobson 2018]
-"
+            "\n\t0: Use fast pseudo-normal test [Bærentzen & Aanæs 2005]"
+            "\n\t1: Use winding number [Jacobson, Kavan Sorking-Hornug 2013]"
+            "\n\t2: Default (pseudo-normal)"
+            "\n\t3: Unsigned"
+            "\n\t4: Use Fast winding number [Barill, Dickson, Schmidt, Levin, Jacobson 2018]\n"
         );
     }
 
@@ -109,3 +96,6 @@ npe_begin_code()
     }
 
 npe_end_code()
+
+
+

--- a/src/signed_distance.cpp
+++ b/src/signed_distance.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Francis Williams
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/simplify_polyhedron.cpp
+++ b/src/simplify_polyhedron.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/simplify_polyhedron.cpp
+++ b/src/simplify_polyhedron.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/snap_points.cpp
+++ b/src/snap_points.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <common.h>

--- a/src/snap_points.cpp
+++ b/src/snap_points.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <common.h>

--- a/src/solid_angle.cpp
+++ b/src/solid_angle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -59,5 +66,3 @@ npe_begin_code()
   return res;
 
 npe_end_code()
-
-

--- a/src/solid_angle.cpp
+++ b/src/solid_angle.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -66,3 +59,5 @@ npe_begin_code()
   return res;
 
 npe_end_code()
+
+

--- a/src/solid_angle.cpp
+++ b/src/solid_angle.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/sort_angles.cpp
+++ b/src/sort_angles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -51,5 +58,3 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
-
-

--- a/src/sort_angles.cpp
+++ b/src/sort_angles.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/sort_angles.cpp
+++ b/src/sort_angles.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -58,3 +51,5 @@ npe_begin_code()
   return npe::move(r);
 
 npe_end_code()
+
+

--- a/src/sparse_voxel_grid.cpp
+++ b/src/sparse_voxel_grid.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -74,3 +67,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(cs), npe::move(cv), npe::move(ci));
 
 npe_end_code()
+
+

--- a/src/sparse_voxel_grid.cpp
+++ b/src/sparse_voxel_grid.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -67,5 +74,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(cs), npe::move(cv), npe::move(ci));
 
 npe_end_code()
-
-

--- a/src/sparse_voxel_grid.cpp
+++ b/src/sparse_voxel_grid.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/swept_volume_bounding_box.cpp
+++ b/src/swept_volume_bounding_box.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <pybind11/functional.h>

--- a/src/swept_volume_bounding_box.cpp
+++ b/src/swept_volume_bounding_box.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <pybind11/functional.h>

--- a/src/tet_tet_adjacency.cpp
+++ b/src/tet_tet_adjacency.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>

--- a/src/tet_tet_adjacency.cpp
+++ b/src/tet_tet_adjacency.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>

--- a/src/topological_hole_fill.cpp
+++ b/src/topological_hole_fill.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/topological_hole_fill.cpp
+++ b/src/topological_hole_fill.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/triangle/triangulate.cpp
+++ b/src/triangle/triangulate.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <pybind11/stl.h>
 
 #include <npe.h>
@@ -61,4 +68,3 @@ if(VM.size() == 0 && EM.size() == 0)
 }
 
 npe_end_code()
-

--- a/src/triangle/triangulate.cpp
+++ b/src/triangle/triangulate.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <pybind11/stl.h>
 
 #include <npe.h>

--- a/src/triangle/triangulate.cpp
+++ b/src/triangle/triangulate.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <pybind11/stl.h>
 
 #include <npe.h>
@@ -68,3 +61,4 @@ if(VM.size() == 0 && EM.size() == 0)
 }
 
 npe_end_code()
+

--- a/src/triangle_fan.cpp
+++ b/src/triangle_fan.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/triangle_fan.cpp
+++ b/src/triangle_fan.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/triangle_triangle_adjacency.cpp
+++ b/src/triangle_triangle_adjacency.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>
@@ -58,3 +51,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(tt), npe::move(t_ti));
 
 npe_end_code()
+
+

--- a/src/triangle_triangle_adjacency.cpp
+++ b/src/triangle_triangle_adjacency.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>

--- a/src/triangle_triangle_adjacency.cpp
+++ b/src/triangle_triangle_adjacency.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>
@@ -51,5 +58,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(tt), npe::move(t_ti));
 
 npe_end_code()
-
-

--- a/src/triangles_from_strip.cpp
+++ b/src/triangles_from_strip.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/triangles_from_strip.h>
@@ -59,3 +52,5 @@ npe_begin_code()
   return npe::move(f);
 
 npe_end_code()
+
+

--- a/src/triangles_from_strip.cpp
+++ b/src/triangles_from_strip.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/triangles_from_strip.h>
@@ -52,5 +59,3 @@ npe_begin_code()
   return npe::move(f);
 
 npe_end_code()
-
-

--- a/src/triangles_from_strip.cpp
+++ b/src/triangles_from_strip.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 #include <igl/triangles_from_strip.h>

--- a/src/triangulated_grid.cpp
+++ b/src/triangulated_grid.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/triangulated_grid.cpp
+++ b/src/triangulated_grid.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/two_axis_valuator_fixed_up.cpp
+++ b/src/two_axis_valuator_fixed_up.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/two_axis_valuator_fixed_up.cpp
+++ b/src/two_axis_valuator_fixed_up.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -85,5 +92,3 @@ npe_begin_code()
   return npe::move(quat);
 
 npe_end_code()
-
-

--- a/src/two_axis_valuator_fixed_up.cpp
+++ b/src/two_axis_valuator_fixed_up.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -92,3 +85,5 @@ npe_begin_code()
   return npe::move(quat);
 
 npe_end_code()
+
+

--- a/src/uniformly_sample_two_manifold.cpp
+++ b/src/uniformly_sample_two_manifold.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>

--- a/src/uniformly_sample_two_manifold.cpp
+++ b/src/uniformly_sample_two_manifold.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -123,3 +116,5 @@ npe_begin_code()
   return npe::move(s_out);
 
 npe_end_code()
+
+

--- a/src/uniformly_sample_two_manifold.cpp
+++ b/src/uniformly_sample_two_manifold.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __example
 
 #include <common.h>
@@ -116,5 +123,3 @@ npe_begin_code()
   return npe::move(s_out);
 
 npe_end_code()
-
-

--- a/src/unique_edge_map.cpp
+++ b/src/unique_edge_map.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/unique_edge_map.cpp
+++ b/src/unique_edge_map.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/unique_simplices.cpp
+++ b/src/unique_simplices.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -51,3 +44,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(ff), npe::move(ia), npe::move(ic));
 
 npe_end_code()
+
+

--- a/src/unique_simplices.cpp
+++ b/src/unique_simplices.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -44,5 +51,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(ff), npe::move(ia), npe::move(ic));
 
 npe_end_code()
-
-

--- a/src/unique_simplices.cpp
+++ b/src/unique_simplices.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/unproject.cpp
+++ b/src/unproject.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/unproject.cpp
+++ b/src/unproject.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 #include <common.h>
 #include <npe.h>

--- a/src/unproject_in_mesh.cpp
+++ b/src/unproject_in_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/unproject_in_mesh.cpp
+++ b/src/unproject_in_mesh.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -86,3 +79,4 @@ npe_begin_code()
   return std::make_tuple(npe::move(obj), hits);
 
 npe_end_code()
+

--- a/src/unproject_in_mesh.cpp
+++ b/src/unproject_in_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -79,4 +86,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(obj), hits);
 
 npe_end_code()
-

--- a/src/unproject_on_line.cpp
+++ b/src/unproject_on_line.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -72,4 +79,3 @@ npe_begin_code()
   return std::make_tuple(double(t), npe::move(Z));
 
 npe_end_code()
-

--- a/src/unproject_on_line.cpp
+++ b/src/unproject_on_line.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/unproject_on_line.cpp
+++ b/src/unproject_on_line.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -79,3 +72,4 @@ npe_begin_code()
   return std::make_tuple(double(t), npe::move(Z));
 
 npe_end_code()
+

--- a/src/unproject_on_plane.cpp
+++ b/src/unproject_on_plane.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -67,3 +60,5 @@ npe_begin_code()
   return npe::move(z);
 
 npe_end_code()
+
+

--- a/src/unproject_on_plane.cpp
+++ b/src/unproject_on_plane.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -60,5 +67,3 @@ npe_begin_code()
   return npe::move(z);
 
 npe_end_code()
-
-

--- a/src/unproject_on_plane.cpp
+++ b/src/unproject_on_plane.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/unproject_onto_mesh.cpp
+++ b/src/unproject_onto_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __miss __example
 
 #include <common.h>

--- a/src/unproject_onto_mesh.cpp
+++ b/src/unproject_onto_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __miss __example
 
 #include <common.h>
@@ -78,4 +85,3 @@ npe_begin_code()
   return std::make_tuple(success, fid, npe::move(bc));
 
 npe_end_code()
-

--- a/src/unproject_onto_mesh.cpp
+++ b/src/unproject_onto_mesh.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __miss __example
 
 #include <common.h>
@@ -85,3 +78,4 @@ npe_begin_code()
   return std::make_tuple(success, fid, npe::move(bc));
 
 npe_end_code()
+

--- a/src/unproject_ray.cpp
+++ b/src/unproject_ray.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <common.h>
 #include <npe.h>
@@ -65,3 +58,5 @@ npe_begin_code()
   return std::make_tuple(npe::move(s), npe::move(dir));
 
 npe_end_code()
+
+

--- a/src/unproject_ray.cpp
+++ b/src/unproject_ray.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <common.h>
 #include <npe.h>

--- a/src/unproject_ray.cpp
+++ b/src/unproject_ray.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <common.h>
 #include <npe.h>
@@ -58,5 +65,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(s), npe::move(dir));
 
 npe_end_code()
-
-

--- a/src/upsample.cpp
+++ b/src/upsample.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 //TODO: __miss upsample that retuns a sparse matrix and inplace
 #include <common.h>

--- a/src/upsample.cpp
+++ b/src/upsample.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 //TODO: __miss upsample that retuns a sparse matrix and inplace
 #include <common.h>

--- a/src/vector_area_matrix.cpp
+++ b/src/vector_area_matrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/vector_area_matrix.cpp
+++ b/src/vector_area_matrix.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -45,3 +38,5 @@ npe_begin_code()
   return npe::move(a);
 
 npe_end_code()
+
+

--- a/src/vector_area_matrix.cpp
+++ b/src/vector_area_matrix.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -38,5 +45,3 @@ npe_begin_code()
   return npe::move(a);
 
 npe_end_code()
-
-

--- a/src/vertex_components.cpp
+++ b/src/vertex_components.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -73,6 +80,3 @@ npe_begin_code()
     igl::vertex_components(a, c, counts);
     return std::make_tuple(npe::move(c), npe::move(counts));
 npe_end_code()
-
-
-

--- a/src/vertex_components.cpp
+++ b/src/vertex_components.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/vertex_components.cpp
+++ b/src/vertex_components.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -80,3 +73,6 @@ npe_begin_code()
     igl::vertex_components(a, c, counts);
     return std::make_tuple(npe::move(c), npe::move(counts));
 npe_end_code()
+
+
+

--- a/src/vertex_triangle_adjacency.cpp
+++ b/src/vertex_triangle_adjacency.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 KarlLeell
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>
@@ -60,3 +53,6 @@ npe_begin_code()
   return std::make_tuple(npe::move(vf), npe::move(ni));
 
 npe_end_code()
+
+
+

--- a/src/vertex_triangle_adjacency.cpp
+++ b/src/vertex_triangle_adjacency.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>
@@ -53,6 +60,3 @@ npe_begin_code()
   return std::make_tuple(npe::move(vf), npe::move(ni));
 
 npe_end_code()
-
-
-

--- a/src/vertex_triangle_adjacency.cpp
+++ b/src/vertex_triangle_adjacency.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 KarlLeell
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 // TODO: __miss __example
 
 #include <common.h>

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -187,5 +194,3 @@ npe_begin_code()
   double vol = igl::volume_single(a_copy, b_copy, c_copy, d_copy);
   return vol;
 npe_end_code()
-
-

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>
@@ -194,3 +187,5 @@ npe_begin_code()
   double vol = igl::volume_single(a_copy, b_copy, c_copy, d_copy);
   return vol;
 npe_end_code()
+
+

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <common.h>
 #include <typedefs.h>

--- a/src/winding_number.cpp
+++ b/src/winding_number.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 // TODO: remove __copy
 // copy is necessary since the winding number only supports matrices
@@ -100,5 +107,3 @@ npe_begin_code()
   return igl::winding_number(v_copy, f_copy, p_copy);
 
 npe_end_code()
-
-

--- a/src/winding_number.cpp
+++ b/src/winding_number.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 // TODO: remove __copy
 // copy is necessary since the winding number only supports matrices
@@ -107,3 +100,5 @@ npe_begin_code()
   return igl::winding_number(v_copy, f_copy, p_copy);
 
 npe_end_code()
+
+

--- a/src/winding_number.cpp
+++ b/src/winding_number.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 // TODO: remove __copy
 // copy is necessary since the winding number only supports matrices

--- a/src/writeDMAT.cpp
+++ b/src/writeDMAT.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 
@@ -46,6 +53,3 @@ npe_begin_code()
 return igl::writeDMAT(filename, w, ascii);
 
 npe_end_code()
-
-
-

--- a/src/writeDMAT.cpp
+++ b/src/writeDMAT.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 

--- a/src/writeDMAT.cpp
+++ b/src/writeDMAT.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Alec Jacobson
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <npe.h>
 #include <typedefs.h>
 
@@ -53,3 +46,6 @@ npe_begin_code()
 return igl::writeDMAT(filename, w, ascii);
 
 npe_end_code()
+
+
+

--- a/src/writeOBJ.cpp
+++ b/src/writeOBJ.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Sebastian Koch
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -53,3 +46,7 @@ npe_begin_code()
   return igl::writeOBJ(filename, v, f);
 
 npe_end_code()
+
+
+
+

--- a/src/writeOBJ.cpp
+++ b/src/writeOBJ.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/writeOBJ.cpp
+++ b/src/writeOBJ.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Sebastian Koch
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -46,7 +53,3 @@ npe_begin_code()
   return igl::writeOBJ(filename, v, f);
 
 npe_end_code()
-
-
-
-

--- a/src/writeOFF.cpp
+++ b/src/writeOFF.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Daniele Panozzo
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>

--- a/src/writeOFF.cpp
+++ b/src/writeOFF.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Daniele Panozzo
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -79,3 +72,5 @@ npe_end_code()
 //   return ;
 
 // npe_end_code()
+
+

--- a/src/writeOFF.cpp
+++ b/src/writeOFF.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Daniele Panozzo
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 #include <common.h>
 #include <npe.h>
 #include <typedefs.h>
@@ -72,5 +79,3 @@ npe_end_code()
 //   return ;
 
 // npe_end_code()
-
-

--- a/src/write_triangle_mesh.cpp
+++ b/src/write_triangle_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>
@@ -59,5 +66,3 @@ npe_begin_code()
   return ok;
 
 npe_end_code()
-
-

--- a/src/write_triangle_mesh.cpp
+++ b/src/write_triangle_mesh.cpp
@@ -1,3 +1,10 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Teseo Schneider
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>

--- a/src/write_triangle_mesh.cpp
+++ b/src/write_triangle_mesh.cpp
@@ -1,10 +1,3 @@
-// This file is part of libigl, a simple c++ geometry processing library.
-//
-// Copyright (C) 2023 Teseo Schneider
-//
-// This Source Code Form is subject to the terms of the Mozilla Public License
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can
-// obtain one at http://mozilla.org/MPL/2.0/.
 //TODO: __example
 
 #include <common.h>
@@ -66,3 +59,5 @@ npe_begin_code()
   return ok;
 
 npe_end_code()
+
+


### PR DESCRIPTION
We were missing a license file and copyright headings on these bindings. 

We should probably adjust the wrapper generator scripts to include the copright/license headers.

Given that we have `LIBIGL_COPYLEFT_CGAL` and `LIBIGL_RESTRICTED_TRIANGLE` flags available, users that wish to avoid copyleft or restricted zones can compile from source (while the pypi wheels will continue to include everything).