### PR TITLE
writeMSH binding

### DIFF
--- a/src/writeMSH.cpp
+++ b/src/writeMSH.cpp
@@ -1,0 +1,74 @@
+// This file is part of libigl, a simple c++ geometry processing library.
+//
+// Copyright (C) 2023 Alec Jacobson
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+#include <common.h>
+#include <npe.h>
+#include <typedefs.h>
+#include <igl/writeMSH.h>
+
+const char* ds_writeMSH = R"igl_Qu8mg5v7(
+  /// write triangle surface mesh and tetrahedral volume mesh to .msh file
+  ///
+  /// @param[in] msh - file name
+  /// @param[in] X  eigen double matrix of vertex positions  #X by 3
+  /// @param[in] Tri  #Tri eigen integer matrix of triangular faces indices into vertex positions
+  /// @param[in] Tet  #Tet eigen integer matrix of tetrahedral indices into vertex positions
+  /// @param[in] TriTag #Tri eigen integer vector of tags associated with surface faces
+  /// @param[in] TetTag #Tet eigen integer vector of tags associated with volume elements
+  /// @param[in] XFields #XFields list of strings with field names associated with nodes
+  /// @param[in] XF      #XFields list of eigen double matrices, fields associated with nodes 
+  /// @param[in] EFields #EFields list of strings with field names associated with elements
+  /// @param[in] TriF    #EFields list of eigen double matrices, fields associated with surface elements
+  /// @param[in] TetF    #EFields list of eigen double matrices, fields associated with volume elements
+  ///
+  /// \bug files are always stored in binary format
+  /// \bug file format is 2.2
+  /// \bug only triangle surface elements and tetrahedral volumetric elements are supported
+  /// \bug only 3D information is supported
+  /// \bug the tag id is duplicated for physical (0) and elementary (1)
+  /// \bug same element fields are expected to be associated with surface elements and volumetric elements
+)igl_Qu8mg5v7";
+
+npe_function(writeMSH)
+npe_doc(ds_writeMSH)
+npe_arg(filename, std::string)
+// float not allowed because writeMSH is not templated
+npe_arg(X, dense_double)
+npe_arg(Tri, dense_int32, dense_int64)
+npe_default_arg(Tet, npe_matches(Tri), pybind11::array())
+npe_default_arg(TriTag, npe_matches(Tri), pybind11::array())
+npe_default_arg(TetTag, npe_matches(Tri), pybind11::array())
+
+npe_begin_code()
+
+std::vector<std::string> XFields, EFields;
+std::vector<Eigen::MatrixXd> XF, TriF, TetF;
+Eigen::MatrixXd X_copy = X.template cast<double>();
+Eigen::MatrixXi Tri_copy = Tri.template cast<int>();
+Eigen::MatrixXi Tet_copy = Tet.template cast<int>();
+Eigen::MatrixXi TriTag_copy = TriTag.template cast<int>();
+Eigen::MatrixXi TetTag_copy = TetTag.template cast<int>();
+
+return igl::writeMSH(
+  filename, 
+  X_copy, 
+  Tri_copy,
+  Tet_copy,
+  TriTag_copy,
+  TetTag_copy,
+  XFields,
+  XF,
+  EFields,
+  TriF,
+  TetF);
+
+npe_end_code()
+
+
+
+
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2557,6 +2557,9 @@ class TestBasic(unittest.TestCase):
     def test_writeMESH(self):
         igl.writeMESH("test.mesh",self.v4,self.t4,self.f4)
 
+    def test_writeMSH(self):
+        igl.writeMSH("test.msh",self.v4,self.f4,self.t4)
+
     # copyleft.cgal
     def test_convex_hull(self):
         V = np.array([[0,0,0],[1,0,0],[0,1,0],[0,0,1]],dtype="float64")


### PR DESCRIPTION
Fixes #197 for the most part. The *Fields* are not supported because of the std::vector<MatrixXd> implementation. Perhaps waiting on https://github.com/fwilliams/numpyeigen/issues/65