### PR TITLE
bump libigl to v2.5.0

### DIFF
--- a/cmake/PyiglDependencies.cmake
+++ b/cmake/PyiglDependencies.cmake
@@ -19,7 +19,7 @@ include(FetchContent)
 FetchContent_Declare(
     libigl
     GIT_REPOSITORY https://github.com/libigl/libigl.git
-    GIT_TAG 1b07ebcf9e18c33ba342fd5c945dedbda055df78
+    GIT_TAG v2.5.0
 )
 FetchContent_GetProperties(libigl)
 FetchContent_MakeAvailable(libigl)

--- a/igl/_version.py
+++ b/igl/_version.py
@@ -5,4 +5,4 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-__version__ = "2.5.5dev"
+__version__ = "2.5.0"


### PR DESCRIPTION
forgot to rename branch but this is bumping libigl to 2.5.0

Will upload CI wheels to pypi upon success.