### PR TITLE
Include `cp312`, and don't pin `cibuildwheels`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
         # Launch separate job for each python. The build is so much longer than
         # machine configuration/setup, so parallel builds will be faster. More
         # importantly, github times out after 6 hours _per job_.
-        cpversion: ["cp36", "cp37", "cp38", "cp39", "cp310", "cp311"]
+        cpversion: ["cp36", "cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
         os: [ { runs-on: ubuntu-latest, cibw-arch: manylinux_x86_64}, { runs-on: macos-latest, cibw-arch: macosx_x86_64}, { runs-on: macos-latest, cibw-arch: macosx_arm64}, { runs-on: windows-latest, cibw-arch: win_amd64} ]
         exclude:
           - os: { runs-on: macos-latest, cibw-arch: macosx_arm64}
@@ -73,7 +73,7 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.12.0
+          python -m pip install cibuildwheel
 
       - name: Build wheels
         run: |


### PR DESCRIPTION
Hopefully fixes #221. Seems like [3.12 support was only added in v2.16.2](https://github.com/pypa/cibuildwheel/releases/tag/v2.16.2)