### PR TITLE
bump cibuildhweel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install cibuildwheel==2.22.0
+      - run: pip install cibuildwheel==2.23.0
       - run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "${{ matrix.pybuilds }}-*"  # Use matrix.pybuilds and matrix.arch


### PR DESCRIPTION
This pull request includes a small but important update to the `.github/workflows/wheels.yml` file. The change updates the version of the `cibuildwheel` package used in the workflow.

* [`.github/workflows/wheels.yml`](diffhunk://#diff-75627befeafda60a526c116b32f6fdef9bf57bcf456f840d7592c1d6f13facb4L50-R50): Updated `cibuildwheel` package from version `2.22.0` to `2.23.0`.