### PR TITLE
Adding an optional seed parameter to `random_points_on_mesh`

### DIFF
--- a/src/random_points_on_mesh.cpp
+++ b/src/random_points_on_mesh.cpp
@@ -1,8 +1,10 @@
 #include "default_types.h"
 #include <igl/random_points_on_mesh.h>
+#include <igl/generate_default_urbg.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/eigen/dense.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/optional.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -13,11 +15,13 @@ namespace pyigl
   auto random_points_on_mesh(
     const Integer n,
     const nb::DRef<const Eigen::MatrixXN> &V,
-    const nb::DRef<const Eigen::MatrixXI> &F)
+    const nb::DRef<const Eigen::MatrixXI> &F,
+    const std::optional<int> seed)
   {
+    std::mt19937 urbg = seed.has_value() ? std::mt19937(*seed) : igl::generate_default_urbg();
     Eigen::VectorXI FI;
     Eigen::MatrixXN B,X;
-    igl::random_points_on_mesh(n, V, F,  B, FI, X);
+    igl::random_points_on_mesh(n, V, F,  B, FI, X, urbg);
     return std::make_tuple(B, FI, X);
   }
 }
@@ -32,6 +36,7 @@ void bind_random_points_on_mesh(nb::module_ &m)
     "n"_a,
     "V"_a,
     "F"_a,
+    "seed"_a = nb::none(),
     R"(
  Randomly sample a mesh (V,F) n times.
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -327,6 +327,19 @@ def test_sample():
     I = igl.knn(X,X,1,point_indices,CH,CN,W)
     B,FI,P = igl.blue_noise(V,F,0.5)
 
+    # Test equal seed yields same result
+    B1,I1,X1 = igl.random_points_on_mesh(10,V,F, 1)
+    B1_,I1_,X1_ = igl.random_points_on_mesh(10,V,F, 1)
+    assert np.all(B1 == B1_)
+    assert np.all(I1 == I1_)
+    assert np.all(X1 == X1_)
+    # Test different seed yields different result
+    B2,I2,X2 = igl.random_points_on_mesh(10,V,F,2)
+    assert not np.all(B1 == B2)
+    assert not np.all(I1 == I2)
+    assert not np.all(X1 == X2)
+
+
 def test_curvature():
     V,F = igl.icosahedron()
     K = igl.gaussian_curvature(V,F)


### PR DESCRIPTION
See issue https://github.com/libigl/libigl-python-bindings/issues/264
