### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ libigl_version = importlib.metadata.version('libigl')
 The version of libigl is defined in the [pyproject.toml](./pyproject.toml) file.
 
 
-## Compiling and modifying the bindiings
+## Compiling and modifying the bindings
 
 According to the [scikit-build-core documentation](https://scikit-build-core.readthedocs.io/en/latest/configuration.html#editable-installs), the way to make an editable (incremental) build is to:
 


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'withing'. Here is your error report:
 https://triplechecker.com/s/8Ls3hX/libigl.github.io

Hope it's helpful!
