### PR TITLE
Add wrapper for vertex_components using adjacency matrix

### DIFF
--- a/src/vertex_components.cpp
+++ b/src/vertex_components.cpp
@@ -2,6 +2,8 @@
 #include <igl/vertex_components.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/eigen/dense.h>
+#include <nanobind/eigen/sparse.h>
+#include <nanobind/stl/tuple.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -15,6 +17,16 @@ namespace pyigl
     Eigen::VectorXI C;
     igl::vertex_components(F, C);
     return C;
+  }
+
+  // Wrapper for vertex_components with adjacency matrix
+  auto vertex_components_from_adjacency_matrix(
+    const Eigen::SparseMatrixI &adjacency)
+  {
+    Eigen::VectorXI c;
+    Eigen::VectorXI counts;
+    igl::vertex_components(adjacency, c, counts);
+    return std::make_tuple(c, counts);
   }
 }
 
@@ -30,4 +42,13 @@ void bind_vertex_components(nb::module_ &m)
 
 @param[in] F       Matrix of triangle indices
 @return            Vector C of component IDs per vertex)");
+
+  m.def(
+    "vertex_components_from_adjacency_matrix",
+    &pyigl::vertex_components_from_adjacency_matrix,
+    "adjacency"_a,
+    R"(Compute the connected components of a graph using an adjacency matrix, returning component IDs and counts.
+
+  @param[in] adjacency  n by n sparse adjacency matrix
+  @return A tuple (c, counts) where c is an array of component ids (starting with 0) and counts is a #components array of counts for each component)");
 }


### PR DESCRIPTION
Restore the `vertex_components_from_adjacency_matrix` previously removed. This is still [referenced in the docs](https://libigl.github.io/libigl-python-bindings/igl_docs/#vertex_components_from_adjacency_matrix). I have a use for this function, so it would be nice to restore.