### PR TITLE
Bump version from 2.6.2.dev0 to 2.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "libigl"
-version = "2.6.2.dev0"
+version = "2.6.2"
 description = "libigl: A simple C++ geometry processing library"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
I'm not sure what the best way is to do version bumps. I guess I'll use the PR to trigger the CI build wheels action, upload the wheels to pypi and then not merge it to main